### PR TITLE
Update field descriptions in language.yaml

### DIFF
--- a/config/language/language.yaml
+++ b/config/language/language.yaml
@@ -36,7 +36,7 @@ levtype:
     - type: ssd
 
 class:
-  description: Top-level grouping of data
+  description: Main category of dataset
   category: data
   default: od
   flatten: false


### PR DESCRIPTION
### Description

We need complete and homogeneous information about the (DestinE Digital Twin) Polytope fields to surface this in an application (contract DE_394). 

- https://github.com/ecmwf/qubed/issues/5

I would be happy for us to contribute to a centrally maintained registry of this information, for now here in `language.yaml`, so we have a commonly curated reference.

### What I changed

I offer a bit of opinionated copy-editing of `language.yaml`. If there are editorial guidelines that I should follow, please let me know.

1. Revised the `description`s for all fields to use common structure (describing the thing, not what to do with it)
2. Removed the duplicate `param` field
3. Factored in the `type` descriptions that were previously uncommented
4. Applied +1 indentation level for lists (editor did that, it has [no functional effects](https://stackoverflow.com/a/71968274))

### How you can review this

The diff became quite large, so GitHub won't render it online. Pls diff locally.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 