### PR TITLE
fix: Add QEnum dtype inference

### DIFF
--- a/src/python/qubed/value_types.py
+++ b/src/python/qubed/value_types.py
@@ -141,7 +141,22 @@ class QEnum(ValueGroup):
     values: EnumValuesType
     _dtype: str = "str"
 
-    def __init__(self, obj, dtype="str"):
+    def __init__(self, obj, dtype: str | None = None):
+        if dtype is None:
+            values_dtype = set(list(map(type, obj)))
+            if len(values_dtype) > 1:
+                raise ValueError(
+                    f"All values must be of the same type, but found {values_dtype}"
+                )
+            elif len(values_dtype) == 0:
+                dtype = "str"
+            else:
+                dtype = _dtype_map_inv.get(values_dtype.pop(), None)
+
+            if dtype is None:
+                raise ValueError(
+                    f"data type not allowed {dtype}, currently only {_dtype_map_inv.keys()} are supported."
+                )
         object.__setattr__(self, "values", tuple(sorted(obj)))
         object.__setattr__(
             self,

--- a/tests/test_value_types.py
+++ b/tests/test_value_types.py
@@ -1,0 +1,43 @@
+import pytest
+import datetime
+
+from qubed.value_types import QEnum
+
+
+@pytest.mark.parametrize(
+    "values, expected_dtype",
+    [
+        ([1, 2, 3], "int64"),
+        ([1.0, 2.0, 3.0], "float64"),
+        (["a", "b", "c"], "str"),
+        ([], "str"),  # Empty list should default to str
+        ([datetime.date(2020, 1, 1), datetime.date(2020, 1, 2)], "date"),
+        (
+            [
+                datetime.datetime(2020, 1, 1, 12, 0),
+                datetime.datetime(2020, 1, 2, 12, 0),
+            ],
+            "datetime",
+        ),
+    ],
+)
+def test_qenum_dtype_inference(values, expected_dtype):
+    qenum = QEnum(values)
+    assert qenum.dtype == expected_dtype
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        [1, 2.0, 3],  # Mixed int and float
+        [1, "2", 3],  # Mixed int and str
+        [1.0, "2.0", 3.0],  # Mixed float and str
+        [
+            datetime.date(2020, 1, 1),
+            datetime.datetime(2020, 1, 1, 12, 0),
+        ],  # Mixed date and datetime
+    ],
+)
+def test_qenum_dtype_inference_mixed(values):
+    with pytest.raises(ValueError):
+        QEnum(values)


### PR DESCRIPTION
### Description
Add QEnum dtype inference
Closes #61 

```python
from qubed.value_types import QEnum

QEnum([0,1]).dtype == "int64"
```

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-URL_BEGIN -->
🌈🌦️📖🚧 Documentation 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/dev-section/qubed/pull-requests/PR-62
<!-- PREVIEW-URL_END -->