### PR TITLE
feat: backward-compatible Python API improvements (umbrella)

### DIFF
--- a/docs/src/python/py_qubed.md
+++ b/docs/src/python/py_qubed.md
@@ -355,7 +355,7 @@ q3 = copy.deepcopy(q)
 | Method | Description |
 |---|---|
 | `__str__()` | Same as `to_ascii()` |
-| `__repr__()` | Returns `Qube(root_id=...)` |
+| `__repr__()` | Same as `to_ascii()` |
 | `__len__()` | Returns `datacube_count()` -- the number of leaf identifiers |
 | `__copy__()` | Returns a clone (for `copy.copy`) |
 | `__deepcopy__(memo)` | Returns a clone (for `copy.deepcopy`) |

--- a/docs/src/python/py_qubed.md
+++ b/docs/src/python/py_qubed.md
@@ -1,6 +1,6 @@
-# py_qubed — Python Bindings
+# py_qubed -- Python Bindings
 
-The `py_qubed` package exposes the core `qubed` Rust library to Python via PyO3. It provides the `PyQube` class (importable as `qubed.PyQube`) for building, manipulating, and serializing Qubes from Python.
+The `py_qubed` package exposes the core `qubed` Rust library to Python via PyO3. It provides the `Qube` class (importable as `qubed.Qube`) for building, manipulating, and serialising Qubes from Python.
 
 ## Installation
 
@@ -12,29 +12,38 @@ maturin develop --release
 Then in Python:
 
 ```python
-from qubed import PyQube
+from qubed import Qube
 ```
 
 ---
 
-## PyQube Class
+## Qube Class
 
 ### Construction
 
-#### `PyQube()`
+#### `Qube()`
 
 Create an empty Qube.
 
 ```python
-q = PyQube()
+q = Qube()
 ```
 
-#### `PyQube.from_ascii(text: str) -> PyQube`
+#### `Qube.empty() -> Qube`
+
+Alias for `Qube()` -- creates an empty Qube.
+
+```python
+q = Qube.empty()
+assert q.is_empty()
+```
+
+#### `Qube.from_ascii(text: str) -> Qube`
 
 Parse an ASCII tree representation:
 
 ```python
-q = PyQube.from_ascii("""root
+q = Qube.from_ascii("""root
 ├── class=od
 │   └── expver=0001/0002, param=1/2
 └── class=rd
@@ -42,17 +51,17 @@ q = PyQube.from_ascii("""root
     └── expver=0002, param=1/2""")
 ```
 
-#### `PyQube.from_datacube(datacube: dict[str, str], order: list[str] | None = None) -> PyQube`
+#### `Qube.from_datacube(datacube: dict, order: list[str] | None = None) -> Qube`
 
-Build a Qube from a flat datacube dictionary. Each key is a dimension name and each value is a coordinate string (use `/` to specify multiple values for a dimension, e.g. `"1/2/3"`).
+Build a Qube from a flat datacube dictionary. Each key is a dimension name and each value is a coordinate string (use `/` to specify multiple values for a dimension, e.g. `"1/2/3"`), an integer, a float, or a list of values.
 
-The optional `order` list controls the nesting order of dimensions in the resulting tree — dimensions listed first become shallower levels. Any dimensions not in `order` are appended at deeper levels in an unspecified order. When `order` is `None`, all dimension ordering is unspecified.
+The optional `order` list controls the nesting order of dimensions in the resulting tree -- dimensions listed first become shallower levels. Any dimensions not in `order` are appended at deeper levels in sorted order. When `order` is `None`, all dimensions are sorted alphabetically.
 
 This is the inverse of `to_datacubes()`: a single dict from that list can be passed back here to reconstruct a single-branch Qube.
 
 ```python
 # Single identifier
-q = PyQube.from_datacube({"class": "od", "expver": "0001", "param": "1"}, ["class", "expver", "param"])
+q = Qube.from_datacube({"class": "od", "expver": "0001", "param": "1"}, ["class", "expver", "param"])
 print(q)
 # root
 # └── class=od
@@ -60,30 +69,48 @@ print(q)
 #         └── param=1
 
 # Multiple values on a dimension
-q = PyQube.from_datacube({"class": "od", "param": "1/2/3"}, ["class", "param"])
+q = Qube.from_datacube({"class": "od", "param": "1/2/3"}, ["class", "param"])
 print(q.all_unique_dim_coords())
-# {'class': ['od'], 'param': ['1', '2', '3']}
+# {'class': ['od'], 'param': [1, 2, 3]}
 
 # Roundtrip from to_datacubes
-original = PyQube.from_ascii("root\n└── class=od, expver=0001, param=1")
+original = Qube.from_ascii("root\n└── class=od, expver=0001, param=1")
 for dc in original.to_datacubes():
-    rebuilt = PyQube.from_datacube(dc, ["class", "expver", "param"])
+    rebuilt = Qube.from_datacube(dc, ["class", "expver", "param"])
 ```
 
-#### `PyQube.from_arena_json(json_str: str) -> PyQube`
+#### `Qube.from_arena_json(json_str: str | dict) -> Qube`
 
-Reconstruct a Qube from arena JSON (a flat BFS array produced by `to_arena_json`):
+Reconstruct a Qube from arena JSON (a flat BFS array produced by `to_arena_json`). Accepts either a JSON string or a Python dict/list.
 
 ```python
 import json
 
 arena_str = q.to_arena_json()
-restored = PyQube.from_arena_json(arena_str)
+restored = Qube.from_arena_json(arena_str)
+```
+
+#### `Qube.from_json(input: str | dict) -> Qube`
+
+Reconstruct a Qube from nested JSON (produced by `to_json`). Accepts either a JSON string or a Python dict.
+
+```python
+json_str = q.to_json()
+restored = Qube.from_json(json_str)
+```
+
+#### `Qube.from_tree_json(input: str | dict) -> Qube`
+
+Reconstruct a Qube from tree JSON (produced by `to_tree_json`). Each node has `key`, `values`, `metadata`, and `children` fields.
+
+```python
+tree_str = q.to_tree_json()
+restored = Qube.from_tree_json(tree_str)
 ```
 
 ---
 
-### Serialization
+### Serialisation
 
 #### `to_ascii() -> str`
 
@@ -114,15 +141,35 @@ for node in arena:
 
 Each record: `{ "dim": "class", "coords": "od/rd", "parent": 0, "children": [1, 2] }`
 
+#### `to_json() -> str`
+
+Return a nested JSON string where each node is a key-value pair using `"dim=coords"` keys:
+
+```python
+import json
+print(json.loads(q.to_json()))
+# {"class=od": {"expver=0001/0002": {"param=1/2": {}}}, ...}
+```
+
+#### `to_tree_json() -> str`
+
+Return a tree-structured JSON string where each node has `key`, `values`, `metadata`, and `children` fields:
+
+```python
+import json
+tree = json.loads(q.to_tree_json())
+# {"key": "root", "values": {...}, "metadata": {}, "children": [...]}
+```
+
 #### `to_datacubes() -> list[dict]`
 
-Decompose into a list of datacube dictionaries. Each dict maps dimension names to coordinate strings:
+Decompose into a list of datacube dictionaries. Each dict maps dimension names to coordinate values. Single-value coordinates are returned as scalars; multi-value coordinates as lists:
 
 ```python
 for dc in q.to_datacubes():
     print(dc)
-# {'class': 'od', 'expver': '0001/0002', 'param': '1/2'}
-# {'class': 'rd', 'expver': '0001', 'param': '1/2/3'}
+# {'class': 'od', 'expver': '0001', 'param': 1}
+# {'class': 'rd', 'expver': '0001', 'param': 1}
 # ...
 ```
 
@@ -130,51 +177,56 @@ for dc in q.to_datacubes():
 
 ### Merging
 
-#### `append(other: PyQube) -> None`
+#### `append(other: Qube) -> None`
 
 Merge another Qube into this one. The result is automatically compressed. `other` becomes empty.
 
 ```python
-a = PyQube.from_ascii("root\n└── class=od, param=1")
-b = PyQube.from_ascii("root\n└── class=rd, param=2")
+a = Qube.from_ascii("root\n└── class=od, param=1")
+b = Qube.from_ascii("root\n└── class=rd, param=2")
 a.append(b)
 print(a)
 ```
 
-#### `append_many(others: list[PyQube]) -> None`
+#### `append_many(others: list[Qube]) -> None`
 
 Merge multiple Qubes at once:
 
 ```python
-base = PyQube()
-qubes = [PyQube.from_ascii(f"root\n└── class=c{i}, param=1") for i in range(100)]
+base = Qube()
+qubes = [Qube.from_ascii(f"root\n└── class=c{i}, param=1") for i in range(100)]
 base.append_many(qubes)
 ```
 
-#### `append_datacube(datacube: dict[str, str], order: list[str] | None = None, accept_existing_order: bool = False) -> None`
+#### `append_datacube(datacube: dict, order: list[str] | None = None, accept_existing_order: bool = False) -> None`
 
 Merge a single flat datacube dictionary into this Qube in-place. This is a convenience wrapper around `from_datacube` + `append`: it constructs a temporary single-branch Qube from `datacube` and merges it, then compresses the result.
 
 `order` controls the dimension nesting order of the new branch (see `from_datacube`). `accept_existing_order` is reserved for future use.
 
 ```python
-q = PyQube.from_ascii("""root
+q = Qube.from_ascii("""root
 └── class=od
     └── expver=0001
         └── param=1""")
 
 q.append_datacube({"class": "od", "expver": "0002", "param": "1"}, ["class", "expver", "param"])
 print(q.all_unique_dim_coords())
-# {'class': ['od'], 'expver': ['0001', '0002'], 'param': ['1']}
+# {'class': ['od'], 'expver': ['0001', '0002'], 'param': [1]}
 
 # Build a Qube incrementally from a list of datacube dicts
-q = PyQube()
+q = Qube()
 for dc in [{"class": "od", "param": "1"}, {"class": "rd", "param": "2"}]:
     q.append_datacube(dc, ["class", "param"])
 print(q)
-# root
-# └── class=od/rd
-#     └── param=1/2  (structure may vary)
+```
+
+#### `__or__` (pipe operator)
+
+Return a new merged Qube without mutating either operand:
+
+```python
+merged = qube_a | qube_b
 ```
 
 ---
@@ -189,39 +241,39 @@ Compress the Qube in-place. Merges structurally identical sibling nodes, removes
 q.compress()
 ```
 
-#### `drop(dims: list[str]) -> None`
+#### `drop(dims: list[str]) -> Qube`
 
-Remove one or more dimensions from the tree. Children of removed nodes are re-parented to the grandparent, preserving the rest of the structure. The result is automatically compressed.
+Return a new Qube with one or more dimensions removed. Children of removed nodes are re-parented to the grandparent, preserving the rest of the structure. The result is automatically compressed. The original Qube is not modified.
 
 ```python
-q = PyQube.from_ascii("""root
+q = Qube.from_ascii("""root
 └── class=1
     ├── expver=0001
     │   └── param=1/2
     └── expver=0002
         └── param=1/2""")
 
-q.drop(["expver"])
-print(q)
+q2 = q.drop(["expver"])
+print(q2)
 # root
 # └── class=1
 #     └── param=1/2
 ```
 
-#### `squeeze() -> None`
+#### `squeeze() -> Qube`
 
-Drop all dimensions that have only a single coordinate value. Equivalent to calling `drop` on every dimension whose union of values has length 1.
+Return a new Qube with all single-value dimensions removed. Equivalent to calling `drop` on every dimension whose union of values has length 1. The original Qube is not modified.
 
 ```python
-q = PyQube.from_ascii("""root
+q = Qube.from_ascii("""root
 └── class=1
     ├── expver=0001
     │   └── param=1/2
     └── expver=0002
         └── param=1/2""")
 
-q.squeeze()
-print(q)
+q2 = q.squeeze()
+print(q2)
 # root
 # └── expver=0001/0002
 #     └── param=1/2
@@ -231,25 +283,69 @@ print(q)
 
 ### Query
 
-#### `all_unique_dim_coords() -> dict[str, list[str]]`
+#### `is_empty() -> bool`
 
-Return a dictionary mapping each dimension name to a list of all coordinate values that appear anywhere in the Qube.
+Return whether the Qube has no children (only a root node).
+
+```python
+q = Qube()
+assert q.is_empty()
+```
+
+#### `all_unique_dim_coords() -> dict[str, list]`
+
+Return a dictionary mapping each dimension name to a list of all coordinate values that appear anywhere in the Qube. Values are always returned as lists, with native types preserved (integers, floats, strings).
 
 ```python
 coords = q.all_unique_dim_coords()
-# {'class': ['1'], 'expver': ['0001', '0002'], 'param': ['1', '2']}
+# {'class': [1], 'expver': ['0001', '0002'], 'param': [1, 2]}
 ```
 
-#### `select(request: dict, mode: str | None, consume: bool | None) -> PyQube`
+#### `axes() -> dict[str, list]`
+
+Alias for `all_unique_dim_coords()`.
+
+```python
+coords = q.axes()
+```
+
+#### `dimensions() -> set[str]`
+
+Return the set of dimension names present in the tree.
+
+```python
+dims = q.dimensions()
+# {'class', 'expver', 'param'}
+```
+
+#### `select(request: dict, mode: str | None, consume: bool | None) -> Qube`
 
 Return a new Qube containing only the identifiers that satisfy the request. Each key in `request` is a dimension name; values may be a single string/int or a list.
 
 `mode` controls behaviour for dimensions absent in a branch:
-- `None` / any other string — default: keep branches that have at least one matching value.
-- `"prune"` — additionally remove branches that are missing any requested dimension entirely.
+- `None` / any other string -- default: keep branches that have at least one matching value.
+- `"prune"` -- additionally remove branches that are missing any requested dimension entirely.
 
 ```python
 selected = q.select({"class": [1], "param": [1, 2]}, None, None)
+```
+
+---
+
+### Copying
+
+#### `clone_qube() -> Qube`
+
+Return a deep copy of this Qube.
+
+#### `__copy__()` / `__deepcopy__(memo)`
+
+Support for `copy.copy(q)` and `copy.deepcopy(q)`. Both produce independent clones since the Qube is pure Rust data with no Python object references.
+
+```python
+import copy
+q2 = copy.copy(q)
+q3 = copy.deepcopy(q)
 ```
 
 ---
@@ -259,11 +355,14 @@ selected = q.select({"class": [1], "param": [1, 2]}, None, None)
 | Method | Description |
 |---|---|
 | `__str__()` | Same as `to_ascii()` |
-| `__repr__()` | Returns `PyQube(root_id=...)` |
-| `__len__()` | Returns `datacube_count()` — the number of leaf identifiers |
+| `__repr__()` | Returns `Qube(root_id=...)` |
+| `__len__()` | Returns `datacube_count()` -- the number of leaf identifiers |
+| `__copy__()` | Returns a clone (for `copy.copy`) |
+| `__deepcopy__(memo)` | Returns a clone (for `copy.deepcopy`) |
+| `__or__(other)` | Returns a new merged Qube (`a | b`) |
 
 ```python
-q = PyQube.from_ascii("root\n├── class=od, param=1/2\n└── class=rd, param=3")
+q = Qube.from_ascii("root\n├── class=od, param=1/2\n└── class=rd, param=3")
 print(len(q))  # 3
 ```
 
@@ -272,11 +371,11 @@ print(len(q))  # 3
 ## Complete Example
 
 ```python
-from qubed import PyQube
+from qubed import Qube
 import json
 
 # Build from ASCII
-q = PyQube.from_ascii("""root
+q = Qube.from_ascii("""root
 ├── class=od
 │   └── expver=0001/0002, param=1/2
 └── class=rd
@@ -286,6 +385,7 @@ q = PyQube.from_ascii("""root
 # Inspect
 print(f"Identifiers: {len(q)}")
 print(q)
+print(q.dimensions())  # {'class', 'expver', 'param'}
 
 # Decompose to datacubes
 for dc in q.to_datacubes():
@@ -293,11 +393,19 @@ for dc in q.to_datacubes():
 
 # Roundtrip through arena JSON
 arena = q.to_arena_json()
-restored = PyQube.from_arena_json(arena)
+restored = Qube.from_arena_json(arena)
+assert str(q) == str(restored)
+
+# Roundtrip through nested JSON
+json_str = q.to_json()
+restored = Qube.from_json(json_str)
 assert str(q) == str(restored)
 
 # Merge two qubes
-other = PyQube.from_ascii("root\n└── class=xd, expver=0001, param=99")
+other = Qube.from_ascii("root\n└── class=xd, expver=0001, param=99")
 q.append(other)
 print(q)
+
+# Or use the | operator for non-mutating merge
+merged = q | other
 ```

--- a/py_qubed/src/lib.rs
+++ b/py_qubed/src/lib.rs
@@ -4,10 +4,11 @@ use ::qubed::Qube;
 use ::qubed::select::SelectMode;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList, PyModule};
+use pyo3::types::{PyDict, PyFloat, PyInt, PyList, PyModule, PyString};
 use serde_json::Value as JsonValue;
 
-#[pyclass(unsendable)]
+#[pyclass(unsendable, name = "Qube", from_py_object)]
+#[derive(Clone)]
 pub struct PyQube {
     inner: Qube,
 }
@@ -17,6 +18,15 @@ impl PyQube {
     #[new]
     pub fn new() -> Self {
         Self { inner: Qube::new() }
+    }
+
+    #[staticmethod]
+    pub fn empty() -> Self {
+        Self { inner: Qube::new() }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
     }
 
     #[staticmethod]
@@ -38,7 +48,7 @@ impl PyQube {
         for datacube in &datacubes {
             let dict = PyDict::new(py);
             for (dimension, coordinates) in datacube.coordinates() {
-                dict.set_item(dimension, coordinates.to_string())?;
+                dict.set_item(dimension, coordinates_to_value(py, coordinates)?)?;
             }
             py_list.append(dict)?;
         }
@@ -52,6 +62,34 @@ impl PyQube {
         serde_json::to_string(&v).map_err(|e| PyTypeError::new_err(e.to_string()))
     }
 
+    pub fn to_json(&self) -> PyResult<String> {
+        let v = self.inner.to_json();
+        serde_json::to_string(&v).map_err(|e| PyTypeError::new_err(e.to_string()))
+    }
+
+    #[staticmethod]
+    pub fn from_json(input: Bound<'_, PyAny>) -> PyResult<Self> {
+        let v = py_to_json_value(&input)?;
+        match Qube::from_json(v) {
+            Ok(qube) => Ok(PyQube { inner: qube }),
+            Err(e) => Err(PyTypeError::new_err(e)),
+        }
+    }
+
+    pub fn to_tree_json(&self) -> PyResult<String> {
+        let v = self.inner.to_tree_json();
+        serde_json::to_string(&v).map_err(|e| PyTypeError::new_err(e.to_string()))
+    }
+
+    #[staticmethod]
+    pub fn from_tree_json(input: Bound<'_, PyAny>) -> PyResult<Self> {
+        let v = py_to_json_value(&input)?;
+        match Qube::from_tree_json(v) {
+            Ok(qube) => Ok(PyQube { inner: qube }),
+            Err(e) => Err(PyTypeError::new_err(e)),
+        }
+    }
+
     #[pyo3(name = "__str__")]
     pub fn py_str(&self) -> PyResult<String> {
         self.to_ascii()
@@ -63,9 +101,8 @@ impl PyQube {
     }
 
     #[staticmethod]
-    pub fn from_arena_json(input: &str) -> PyResult<Self> {
-        let v: JsonValue =
-            serde_json::from_str(input).map_err(|e| PyTypeError::new_err(e.to_string()))?;
+    pub fn from_arena_json(input: Bound<'_, PyAny>) -> PyResult<Self> {
+        let v = py_to_json_value(&input)?;
         match Qube::from_arena_json(v) {
             Ok(qube) => Ok(PyQube { inner: qube }),
             Err(e) => Err(PyTypeError::new_err(e)),
@@ -78,9 +115,10 @@ impl PyQube {
         datacube: Bound<'_, PyDict>,
         order: Option<Vec<String>>,
     ) -> PyResult<Self> {
-        let dc = pydict_to_datacube(datacube)?;
-        let order_slices: Option<&[String]> = order.as_deref();
-        Ok(Self { inner: Qube::from_datacube(&dc, order_slices) })
+        let (dc, key_order) = pydict_to_datacube(datacube)?;
+        // Use explicit order if given, otherwise use the Python dict insertion order
+        let effective_order = order.unwrap_or(key_order);
+        Ok(Self { inner: Qube::from_datacube(&dc, Some(&effective_order)) })
     }
 
     #[pyo3(signature = (datacube, order=None, accept_existing_order=false))]
@@ -90,12 +128,13 @@ impl PyQube {
         order: Option<Vec<String>>,
         accept_existing_order: bool,
     ) -> PyResult<()> {
-        let dc = pydict_to_datacube(datacube)?;
-        let order_slices: Option<&[String]> = order.as_deref();
-        self.inner.append_datacube(dc, order_slices, accept_existing_order);
+        let (dc, key_order) = pydict_to_datacube(datacube)?;
+        let effective_order = order.unwrap_or(key_order);
+        self.inner.append_datacube(dc, Some(&effective_order), accept_existing_order);
         Ok(())
     }
 
+    #[pyo3(signature = (request, mode=None, _consume=None))]
     pub fn select(
         &self,
         request: Bound<'_, PyDict>,
@@ -144,25 +183,38 @@ impl PyQube {
         let py_dict = PyDict::new(py);
 
         for (dimension, coordinates) in dim_coords {
-            let coord_str = coordinates.to_string();
-            // Split on slash if present, otherwise treat as single value
-            let values: Vec<&str> = if coord_str.is_empty() {
-                vec![]
-            } else if coord_str.contains('/') {
-                coord_str.split('/').collect()
-            } else {
-                vec![&coord_str]
-            };
-
-            let py_list = PyList::empty(py);
-            for value in values {
-                py_list.append(value)?;
-            }
-
-            py_dict.set_item(dimension, py_list)?;
+            py_dict.set_item(dimension, coordinates_to_list(py, &coordinates)?)?;
         }
 
         Ok(py_dict.into_any().unbind())
+    }
+
+    /// Return ``{dim: [values...]}`` for every dimension in the tree.
+    pub fn axes(&mut self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        // Delegates to the same Rust method; kept as a separate Python name
+        // so callers can use the more natural ``qube.axes()`` spelling.
+        self.all_unique_dim_coords(py)
+    }
+
+    /// Return the set of dimension names present in the tree.
+    pub fn dimensions(&mut self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let dims = self.inner.dimensions();
+        let py_set = pyo3::types::PySet::new(py, &dims)?;
+        Ok(py_set.into_any().unbind())
+    }
+
+    /// Return a deep copy of this Qube.
+    pub fn clone_qube(&self) -> Self {
+        PyQube { inner: self.inner.clone() }
+    }
+
+    /// Python ``copy.copy`` / ``copy.deepcopy`` support.
+    pub fn __copy__(&self) -> Self {
+        self.clone_qube()
+    }
+
+    pub fn __deepcopy__(&self, _memo: &Bound<'_, PyAny>) -> Self {
+        self.clone_qube()
     }
 
     pub fn compress(&mut self) -> PyResult<()> {
@@ -170,7 +222,7 @@ impl PyQube {
         Ok(())
     }
 
-    pub fn drop(&mut self, dims: &Bound<'_, PyList>) -> PyResult<()> {
+    pub fn drop(&self, dims: &Bound<'_, PyList>) -> PyResult<Self> {
         let to_drop: Vec<String> = dims
             .iter()
             .map(|item| {
@@ -179,11 +231,15 @@ impl PyQube {
                     .map_err(|_| PyTypeError::new_err("drop: dimension names must be strings"))
             })
             .collect::<PyResult<_>>()?;
-        self.inner.drop(to_drop).map_err(PyTypeError::new_err)
+        let mut result = self.inner.clone();
+        result.drop(to_drop).map_err(PyTypeError::new_err)?;
+        Ok(PyQube { inner: result })
     }
 
-    pub fn squeeze(&mut self) -> PyResult<()> {
-        self.inner.squeeze().map_err(PyTypeError::new_err)
+    pub fn squeeze(&self) -> PyResult<Self> {
+        let mut result = self.inner.clone();
+        result.squeeze().map_err(PyTypeError::new_err)?;
+        Ok(PyQube { inner: result })
     }
 
     pub fn append(&mut self, other: &Bound<'_, PyQube>) -> PyResult<()> {
@@ -192,12 +248,20 @@ impl PyQube {
         Ok(())
     }
 
+    #[pyo3(name = "__or__")]
+    pub fn _or_wrapper(&self, other: &Bound<'_, PyQube>) -> PyResult<Self> {
+        let mut result = self.inner.clone();
+        let mut other_inner = other.borrow().inner.clone();
+        result.append(&mut other_inner);
+        Ok(PyQube { inner: result })
+    }
+
     pub fn append_many(&mut self, others: &Bound<'_, PyList>) -> PyResult<()> {
         // First validate all types so type errors happen before any mutation.
         let mut validated_qubes = Vec::with_capacity(others.len());
         for item in others.iter() {
             let other_cell =
-                item.cast::<PyQube>().map_err(|_| PyTypeError::new_err("expected PyQube"))?;
+                item.cast::<PyQube>().map_err(|_| PyTypeError::new_err("expected Qube"))?;
             validated_qubes.push(other_cell.clone().unbind());
         }
 
@@ -211,19 +275,107 @@ impl PyQube {
     }
 
     pub fn __repr__(&self) -> PyResult<String> {
-        Ok(format!("PyQube(root_id={:?})", self.inner.root()))
+        self.to_ascii()
     }
 }
 
-fn pydict_to_datacube(datacube: Bound<'_, PyDict>) -> PyResult<Datacube> {
+fn json_scalar_to_py<'py>(
+    py: Python<'py>,
+    val: &serde_json::Value,
+) -> PyResult<pyo3::Bound<'py, PyAny>> {
+    match val {
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Ok(i.into_pyobject(py)?.into_any())
+            } else if let Some(f) = n.as_f64() {
+                Ok(f.into_pyobject(py)?.into_any())
+            } else {
+                Ok(n.to_string().into_pyobject(py)?.into_any())
+            }
+        }
+        serde_json::Value::String(s) => Ok(s.as_str().into_pyobject(py)?.into_any()),
+        _ => Ok(val.to_string().into_pyobject(py)?.into_any()),
+    }
+}
+
+/// Convert Coordinates to a Python list (always returns a list, even for single elements).
+fn coordinates_to_list(py: Python<'_>, coords: &Coordinates) -> PyResult<Py<PyAny>> {
+    match coords.to_json_value() {
+        serde_json::Value::Array(arr) if arr.is_empty() => {
+            Ok(PyList::empty(py).into_any().unbind())
+        }
+        serde_json::Value::Array(arr) => {
+            let list = PyList::empty(py);
+            for v in &arr {
+                list.append(json_scalar_to_py(py, v)?)?;
+            }
+            Ok(list.into_any().unbind())
+        }
+        serde_json::Value::String(s) => Ok(s.into_pyobject(py)?.into_any().unbind()),
+        other => Ok(other.to_string().into_pyobject(py)?.into_any().unbind()),
+    }
+}
+
+/// Convert Coordinates to a Python value, unwrapping single-element arrays to scalars.
+/// Suitable for datacube entries where each dimension has exactly one value.
+fn coordinates_to_value(py: Python<'_>, coords: &Coordinates) -> PyResult<Py<PyAny>> {
+    match coords.to_json_value() {
+        serde_json::Value::Array(arr) if arr.len() == 1 => {
+            Ok(json_scalar_to_py(py, &arr[0])?.unbind())
+        }
+        _ => coordinates_to_list(py, coords),
+    }
+}
+
+/// Returns (Datacube, key_order) where key_order preserves the Python dict insertion order.
+fn pydict_to_datacube(datacube: Bound<'_, PyDict>) -> PyResult<(Datacube, Vec<String>)> {
     let mut dc = Datacube::new();
+    let mut key_order = Vec::with_capacity(datacube.len());
     for (k, v) in datacube.iter() {
         let key: String =
             k.extract().map_err(|_| PyTypeError::new_err("datacube keys must be strings"))?;
-        let val_str: String = v.str()?.extract()?;
-        dc.add_coordinate(&key, Coordinates::from_string(&val_str));
+        key_order.push(key.clone());
+        let coords = if v.is_instance_of::<PyList>() {
+            let lst =
+                v.downcast::<PyList>().map_err(|e| PyTypeError::new_err(e.to_string()))?;
+            pylist_to_coords(lst)?
+        } else if v.is_instance_of::<PyInt>() {
+            let val: i32 = v.extract()?;
+            Coordinates::from(val)
+        } else if v.is_instance_of::<PyFloat>() {
+            let val: f64 = v.extract()?;
+            Coordinates::from(val)
+        } else {
+            // Scalar string — keep as String coordinate to preserve the
+            // Python type (avoids Mixed coordinates when merging with other
+            // String coordinates for the same dimension).
+            let s: String = v.str()?.extract()?;
+            let mut coords = Coordinates::new();
+            coords.append(s);
+            coords
+        };
+        dc.add_coordinate(&key, coords);
     }
-    Ok(dc)
+    Ok((dc, key_order))
+}
+
+/// Build Coordinates from a Python list, preserving the types of the elements.
+/// If the list contains ints, store as integers. If strings, store as strings.
+fn pylist_to_coords(lst: &Bound<'_, PyList>) -> PyResult<Coordinates> {
+    let mut coords = Coordinates::new();
+    for item in lst.iter() {
+        if item.is_instance_of::<PyInt>() {
+            let val: i32 = item.extract()?;
+            coords.append(val);
+        } else if item.is_instance_of::<PyFloat>() {
+            let val: f64 = item.extract()?;
+            coords.append(val);
+        } else {
+            let s: String = item.str()?.extract()?;
+            coords.append(s);
+        }
+    }
+    Ok(coords)
 }
 
 pub(crate) fn join_pylist_as_path(lst: &Bound<'_, PyList>) -> PyResult<String> {
@@ -235,6 +387,66 @@ pub(crate) fn join_pylist_as_path(lst: &Bound<'_, PyList>) -> PyResult<String> {
         parts.push(s);
     }
     Ok(parts.join("/"))
+}
+
+/// Convert a Python object (str or dict/list) to a serde_json::Value.
+/// Accepts either a JSON string or a Python dict/list directly.
+fn py_to_json_value(input: &Bound<'_, PyAny>) -> PyResult<JsonValue> {
+    if input.is_instance_of::<PyString>() {
+        let s: String = input.extract()?;
+        serde_json::from_str(&s).map_err(|e| PyTypeError::new_err(e.to_string()))
+    } else if input.is_instance_of::<PyDict>() {
+        py_dict_to_json(input.downcast::<PyDict>().unwrap())
+    } else if input.is_instance_of::<PyList>() {
+        py_list_to_json(input.downcast::<PyList>().unwrap())
+    } else {
+        Err(PyTypeError::new_err(
+            "Expected str, dict, or list for JSON input",
+        ))
+    }
+}
+
+/// Recursively convert a Python dict to serde_json::Value::Object.
+fn py_dict_to_json(dict: &Bound<'_, PyDict>) -> PyResult<JsonValue> {
+    let mut map = serde_json::Map::new();
+    for (k, v) in dict.iter() {
+        let key: String =
+            k.extract().map_err(|_| PyTypeError::new_err("JSON object keys must be strings"))?;
+        map.insert(key, py_any_to_json(&v)?);
+    }
+    Ok(JsonValue::Object(map))
+}
+
+/// Recursively convert a Python list to serde_json::Value::Array.
+fn py_list_to_json(list: &Bound<'_, PyList>) -> PyResult<JsonValue> {
+    let arr: Vec<JsonValue> = list.iter().map(|item| py_any_to_json(&item)).collect::<PyResult<_>>()?;
+    Ok(JsonValue::Array(arr))
+}
+
+/// Convert an arbitrary Python object to serde_json::Value.
+fn py_any_to_json(obj: &Bound<'_, PyAny>) -> PyResult<JsonValue> {
+    if obj.is_none() {
+        Ok(JsonValue::Null)
+    } else if obj.is_instance_of::<pyo3::types::PyBool>() {
+        Ok(JsonValue::Bool(obj.extract::<bool>()?))
+    } else if obj.is_instance_of::<PyInt>() {
+        let val: i64 = obj.extract()?;
+        Ok(JsonValue::Number(val.into()))
+    } else if obj.is_instance_of::<PyFloat>() {
+        let val: f64 = obj.extract()?;
+        serde_json::Number::from_f64(val)
+            .map(JsonValue::Number)
+            .ok_or_else(|| PyTypeError::new_err("Float value is not finite"))
+    } else if obj.is_instance_of::<PyString>() {
+        Ok(JsonValue::String(obj.extract::<String>()?))
+    } else if obj.is_instance_of::<PyDict>() {
+        py_dict_to_json(obj.downcast::<PyDict>().unwrap())
+    } else if obj.is_instance_of::<PyList>() {
+        py_list_to_json(obj.downcast::<PyList>().unwrap())
+    } else {
+        // Fallback: convert to string representation
+        Ok(JsonValue::String(obj.str()?.extract::<String>()?))
+    }
 }
 
 #[pymodule]

--- a/py_qubed/src/lib.rs
+++ b/py_qubed/src/lib.rs
@@ -242,6 +242,34 @@ impl PyQube {
         Ok(PyQube { inner: result })
     }
 
+    /// Wrap this Qube under new parent node(s).
+    ///
+    /// Takes a datacube dict `{dim: value}` and optional order, mirroring
+    /// `append_datacube`. The dimensions become ancestors of the current tree
+    /// (outermost first per `order`). Returns a new Qube.
+    ///
+    /// Examples:
+    ///   q.prepend({"dataset": "foo"})
+    ///   q.prepend({"dataset": "foo", "class": "od"}, order=["dataset", "class"])
+    #[pyo3(signature = (datacube, order=None))]
+    pub fn prepend(
+        &self,
+        datacube: Bound<'_, PyDict>,
+        order: Option<Vec<String>>,
+    ) -> PyResult<Self> {
+        let (dc, key_order) = pydict_to_datacube(datacube)?;
+        let effective_order = order.unwrap_or(key_order);
+
+        // Build nested wrappers: first in order is outermost, last is innermost
+        let mut result = self.inner.clone();
+        for dim in effective_order.iter().rev() {
+            if let Some(coords) = dc.coordinates().get(dim) {
+                result = result.prepend(dim, coords.clone());
+            }
+        }
+        Ok(PyQube { inner: result })
+    }
+
     pub fn append(&mut self, other: &Bound<'_, PyQube>) -> PyResult<()> {
         let mut other_mut = other.borrow_mut();
         self.inner.append(&mut other_mut.inner);
@@ -345,13 +373,8 @@ fn pydict_to_datacube(datacube: Bound<'_, PyDict>) -> PyResult<(Datacube, Vec<St
             let val: f64 = v.extract()?;
             Coordinates::from(val)
         } else {
-            // Scalar string — keep as String coordinate to preserve the
-            // Python type (avoids Mixed coordinates when merging with other
-            // String coordinates for the same dimension).
-            let s: String = v.str()?.extract()?;
-            let mut coords = Coordinates::new();
-            coords.append(s);
-            coords
+            let s: String = v.extract().unwrap_or_else(|_| v.str().unwrap().extract().unwrap());
+            Coordinates::from_string(&s)
         };
         dc.add_coordinate(&key, coords);
     }

--- a/py_qubed/src/lib.rs
+++ b/py_qubed/src/lib.rs
@@ -336,8 +336,7 @@ fn pydict_to_datacube(datacube: Bound<'_, PyDict>) -> PyResult<(Datacube, Vec<St
             k.extract().map_err(|_| PyTypeError::new_err("datacube keys must be strings"))?;
         key_order.push(key.clone());
         let coords = if v.is_instance_of::<PyList>() {
-            let lst =
-                v.downcast::<PyList>().map_err(|e| PyTypeError::new_err(e.to_string()))?;
+            let lst = v.downcast::<PyList>().map_err(|e| PyTypeError::new_err(e.to_string()))?;
             pylist_to_coords(lst)?
         } else if v.is_instance_of::<PyInt>() {
             let val: i32 = v.extract()?;
@@ -400,9 +399,7 @@ fn py_to_json_value(input: &Bound<'_, PyAny>) -> PyResult<JsonValue> {
     } else if input.is_instance_of::<PyList>() {
         py_list_to_json(input.downcast::<PyList>().unwrap())
     } else {
-        Err(PyTypeError::new_err(
-            "Expected str, dict, or list for JSON input",
-        ))
+        Err(PyTypeError::new_err("Expected str, dict, or list for JSON input"))
     }
 }
 
@@ -419,7 +416,8 @@ fn py_dict_to_json(dict: &Bound<'_, PyDict>) -> PyResult<JsonValue> {
 
 /// Recursively convert a Python list to serde_json::Value::Array.
 fn py_list_to_json(list: &Bound<'_, PyList>) -> PyResult<JsonValue> {
-    let arr: Vec<JsonValue> = list.iter().map(|item| py_any_to_json(&item)).collect::<PyResult<_>>()?;
+    let arr: Vec<JsonValue> =
+        list.iter().map(|item| py_any_to_json(&item)).collect::<PyResult<_>>()?;
     Ok(JsonValue::Array(arr))
 }
 

--- a/py_qubed/tests/test_qubed_api.py
+++ b/py_qubed/tests/test_qubed_api.py
@@ -410,6 +410,62 @@ def test_squeeze_returns_new_qube() -> None:
 
 
 def test_repr() -> None:
-    """__repr__ should return Qube(root_id=...)."""
-    q = Qube()
-    assert repr(q).startswith("Qube(root_id=")
+    """__repr__ should return the ASCII tree (same as __str__)."""
+    q = Qube.from_ascii("""root
+└── class=od
+    └── param=1
+""")
+    assert "class=od" in repr(q)
+    assert repr(q) == str(q)
+
+
+def test_prepend_wraps_tree_under_new_node() -> None:
+    """prepend({'dim': 'val'}) should wrap the tree under a new parent node."""
+    q = Qube.from_ascii("""root
+├── expver=0001
+│   └── param=1/2
+└── expver=0002
+    └── param=3
+""")
+
+    result = q.prepend({"dataset": "foo"})
+
+    assert "dataset=foo" in result.to_ascii()
+    assert "expver=0001" in result.to_ascii()
+    assert "param=1/2" in result.to_ascii()
+
+    coords = result.all_unique_dim_coords()
+    assert coords["dataset"] == ["foo"]
+    assert set(coords["expver"]) == {"0001", "0002"}
+
+    # Original unchanged
+    assert "dataset" not in q.to_ascii()
+
+
+def test_prepend_with_order() -> None:
+    """prepend with order controls nesting depth."""
+    q = Qube.from_ascii("""root
+└── param=1
+""")
+
+    result = q.prepend({"dataset": "foo", "class": "od"}, order=["dataset", "class"])
+    ascii = result.to_ascii()
+    # dataset should be above class
+    assert ascii.index("dataset") < ascii.index("class")
+
+    coords = result.all_unique_dim_coords()
+    assert coords["dataset"] == ["foo"]
+    assert coords["class"] == ["od"]
+    assert coords["param"] == [1]
+
+
+def test_prepend_with_multiple_values() -> None:
+    """prepend with slash-separated values should create multi-value coords."""
+    q = Qube.from_ascii("""root
+└── param=1
+""")
+
+    result = q.prepend({"class": "od/rd"})
+    coords = result.all_unique_dim_coords()
+    assert set(coords["class"]) == {"od", "rd"}
+    assert coords["param"] == [1]

--- a/py_qubed/tests/test_qubed_api.py
+++ b/py_qubed/tests/test_qubed_api.py
@@ -1,5 +1,6 @@
-from qubed import PyQube
+from qubed import Qube
 import pytest
+import copy
 
 ASCII_INPUT = """root
 └── class=3
@@ -13,7 +14,7 @@ ASCII_INPUT = """root
 
 
 def test_ascii_roundtrip_contains_expected_nodes() -> None:
-    qube = PyQube.from_ascii(ASCII_INPUT)
+    qube = Qube.from_ascii(ASCII_INPUT)
     output = qube.to_ascii()
 
     assert output == ASCII_INPUT
@@ -23,15 +24,15 @@ def test_ascii_roundtrip_contains_expected_nodes() -> None:
 
 def test_append_and_append_many_smoke() -> None:
     # Each source has a distinct class value, so all three should survive the merge.
-    left = PyQube.from_ascii("""root
+    left = Qube.from_ascii("""root
 └── class=1
     └── param=10
 """)
-    right = PyQube.from_ascii("""root
+    right = Qube.from_ascii("""root
 └── class=2
     └── param=20
 """)
-    third = PyQube.from_ascii("""root
+    third = Qube.from_ascii("""root
 └── class=3
     └── param=30
 """)
@@ -46,14 +47,14 @@ def test_append_and_append_many_smoke() -> None:
 
 
 def test_append_many_rejects_non_qube_items() -> None:
-    target = PyQube()
+    target = Qube()
 
-    with pytest.raises(TypeError, match="expected PyQube"):
+    with pytest.raises(TypeError, match="expected Qube"):
         target.append_many(["not-a-qube"])
 
 
 def test_to_datacubes_shape() -> None:
-    qube = PyQube.from_ascii("""root
+    qube = Qube.from_ascii("""root
 └── class=5
     └── param=42
 """)
@@ -61,12 +62,12 @@ def test_to_datacubes_shape() -> None:
     datacubes = qube.to_datacubes()
     assert isinstance(datacubes, list)
     assert len(datacubes) == 1
-    assert datacubes[0]["class"] == "5"
-    assert datacubes[0]["param"] == "42"
+    assert datacubes[0]["class"] == 5
+    assert datacubes[0]["param"] == 42
 
 
 def test_str_and_len_dunder_methods() -> None:
-    qube = PyQube.from_ascii("""root
+    qube = Qube.from_ascii("""root
 └── class=5
     └── param=42
 """)
@@ -75,7 +76,7 @@ def test_str_and_len_dunder_methods() -> None:
 
 
 def test_to_from_arena_json_roundtrip() -> None:
-    qube = PyQube.from_ascii("""root
+    qube = Qube.from_ascii("""root
 └── class=5
     └── param=42
 """)
@@ -91,17 +92,20 @@ def test_to_from_arena_json_roundtrip() -> None:
     # expect qube to be a list with node entries containing dim and coords
     qube_list = parsed["qube"]
     assert isinstance(qube_list, list)
-    assert any(isinstance(item, dict) and "dim" in item and "coords" in item for item in qube_list)
+    assert any(
+        isinstance(item, dict) and "dim" in item and "coords" in item
+        for item in qube_list
+    )
 
     # Reconstruct and verify ascii equality
-    reconstructed = PyQube.from_arena_json(arena_json)
+    reconstructed = Qube.from_arena_json(arena_json)
     assert reconstructed.to_ascii() == qube.to_ascii()
 
 
 def test_from_datacube_basic() -> None:
-    """Build a PyQube from a single datacube dict and verify all dimensions appear."""
+    """Build a Qube from a single datacube dict and verify all dimensions appear."""
     dc = {"class": "od", "expver": "0001", "param": "1"}
-    q = PyQube.from_datacube(dc, ["class", "expver", "param"])
+    q = Qube.from_datacube(dc, ["class", "expver", "param"])
     output = q.to_ascii()
 
     assert "class=od" in output
@@ -112,7 +116,7 @@ def test_from_datacube_basic() -> None:
 def test_from_datacube_order_controls_dimension_levels() -> None:
     """The `order` parameter determines the nesting order of dimensions in the tree."""
     dc = {"class": "od", "expver": "0001", "param": "1"}
-    q = PyQube.from_datacube(dc, ["class", "expver", "param"])
+    q = Qube.from_datacube(dc, ["class", "expver", "param"])
     output = q.to_ascii()
 
     # class must appear before expver, expver before param in the rendered tree
@@ -123,7 +127,7 @@ def test_from_datacube_order_controls_dimension_levels() -> None:
 def test_from_datacube_no_order() -> None:
     """When order is None all dimensions should still be present."""
     dc = {"class": "od", "param": "1"}
-    q = PyQube.from_datacube(dc, None)
+    q = Qube.from_datacube(dc, None)
     output = q.to_ascii()
 
     assert "class=od" in output
@@ -133,28 +137,28 @@ def test_from_datacube_no_order() -> None:
 def test_from_datacube_roundtrip_via_to_datacubes() -> None:
     """from_datacube + to_datacubes should recover the original mapping."""
     dc = {"class": "od", "expver": "0001", "param": "1"}
-    q = PyQube.from_datacube(dc, ["class", "expver", "param"])
+    q = Qube.from_datacube(dc, ["class", "expver", "param"])
     datacubes = q.to_datacubes()
 
     assert len(datacubes) == 1
     assert datacubes[0]["class"] == "od"
     assert datacubes[0]["expver"] == "0001"
-    assert datacubes[0]["param"] == "1"
+    assert datacubes[0]["param"] == 1
 
 
 def test_from_datacube_multi_value_coords() -> None:
     """Coordinates with multiple values (slash-separated) should all be preserved."""
     dc = {"class": "od", "param": "1/2/3"}
-    q = PyQube.from_datacube(dc, ["class", "param"])
+    q = Qube.from_datacube(dc, ["class", "param"])
     coords = q.all_unique_dim_coords()
 
-    assert set(coords["param"]) == {"1", "2", "3"}
+    assert set(coords["param"]) == {1, 2, 3}
     assert coords["class"] == ["od"]
 
 
 def test_append_datacube_merges_new_dimension_values() -> None:
     """append_datacube with a new dimension value should add it to the Qube."""
-    q = PyQube.from_ascii("""root
+    q = Qube.from_ascii("""root
 └── class=od
     └── param=1
 """)
@@ -162,12 +166,12 @@ def test_append_datacube_merges_new_dimension_values() -> None:
     coords = q.all_unique_dim_coords()
 
     assert set(coords["class"]) == {"od", "rd"}
-    assert set(coords["param"]) == {"1"}
+    assert set(coords["param"]) == {1}
 
 
 def test_append_datacube_merges_into_existing_structure() -> None:
     """append_datacube should extend an existing branch rather than duplicate it."""
-    q = PyQube.from_ascii("""root
+    q = Qube.from_ascii("""root
 └── class=od
     └── expver=0001
         └── param=1
@@ -180,12 +184,12 @@ def test_append_datacube_merges_into_existing_structure() -> None:
 
     assert set(coords["expver"]) == {"0001", "0002"}
     assert coords["class"] == ["od"]
-    assert coords["param"] == ["1"]
+    assert coords["param"] == [1]
 
 
 def test_append_datacube_multiple_times_builds_correct_tree() -> None:
     """Calling append_datacube repeatedly should produce the same result as append_many."""
-    q = PyQube()
+    q = Qube()
     for cls in ("a", "b", "c"):
         q.append_datacube({"class": cls, "param": "1"}, ["class", "param"])
 
@@ -193,8 +197,93 @@ def test_append_datacube_multiple_times_builds_correct_tree() -> None:
     assert set(coords["class"]) == {"a", "b", "c"}
 
 
+def test_to_from_json_roundtrip() -> None:
+    """to_json / from_json should round-trip preserving the tree structure."""
+    qube = Qube.from_ascii("""root
+└── class=od
+    ├── expver=0001
+    │   └── param=1
+    └── expver=0002
+        └── param=2
+""")
+
+    json_str = qube.to_json()
+    import json
+
+    parsed = json.loads(json_str)
+    assert isinstance(parsed, dict)
+    # The nested JSON format uses "key=value" as object keys
+    assert any("class=od" in k for k in parsed.keys())
+
+    # Reconstruct and verify ascii equality
+    reconstructed = Qube.from_json(json_str)
+    assert reconstructed.to_ascii() == qube.to_ascii()
+
+
+def test_from_json_invalid_input() -> None:
+    """from_json should raise TypeError on invalid JSON."""
+    with pytest.raises(TypeError):
+        Qube.from_json("not valid json")
+
+
+def test_from_json_non_object_root() -> None:
+    """from_json should raise TypeError when root is not a JSON object."""
+    with pytest.raises(TypeError):
+        Qube.from_json("[1, 2, 3]")
+
+
+def test_to_from_tree_json_roundtrip() -> None:
+    """to_tree_json / from_tree_json should round-trip preserving the tree structure."""
+    qube = Qube.from_ascii("""root
+└── class=od
+    ├── expver=0001
+    │   └── param=1
+    └── expver=0002
+        └── param=2
+""")
+
+    tree_json_str = qube.to_tree_json()
+    import json
+
+    parsed = json.loads(tree_json_str)
+    assert isinstance(parsed, dict)
+    # The tree JSON format has key, values, metadata, children fields
+    assert "key" in parsed
+    assert "values" in parsed
+    assert "children" in parsed
+
+    # Reconstruct and verify ascii equality
+    reconstructed = Qube.from_tree_json(tree_json_str)
+    assert reconstructed.to_ascii() == qube.to_ascii()
+
+
+def test_from_tree_json_invalid_input() -> None:
+    """from_tree_json should raise TypeError on invalid JSON."""
+    with pytest.raises(TypeError):
+        Qube.from_tree_json("not valid json")
+
+
+def test_json_and_tree_json_produce_different_formats() -> None:
+    """to_json and to_tree_json should produce structurally different outputs."""
+    qube = Qube.from_ascii("""root
+└── class=od
+    └── param=1
+""")
+
+    import json
+
+    nested = json.loads(qube.to_json())
+    tree = json.loads(qube.to_tree_json())
+
+    # Nested format uses "key=value" keys
+    assert any("=" in k for k in nested.keys())
+    # Tree format uses "key", "values", "children" structure
+    assert "key" in tree
+    assert "children" in tree
+
+
 def test_arena_preserves_leading_zeros() -> None:
-    qube = PyQube.from_ascii("""root
+    qube = Qube.from_ascii("""root
 └── class=od
     └── expver=0001
         └── param=1
@@ -203,5 +292,124 @@ def test_arena_preserves_leading_zeros() -> None:
     arena_json = qube.to_arena_json()
     assert "0001" in arena_json
 
-    reconstructed = PyQube.from_arena_json(arena_json)
+    reconstructed = Qube.from_arena_json(arena_json)
     assert "expver=0001" in reconstructed.to_ascii()
+
+
+def test_axes_returns_same_as_all_unique_dim_coords() -> None:
+    """axes() is an alias for all_unique_dim_coords()."""
+    q = Qube.from_ascii("""root
+└── class=od
+    ├── expver=0001
+    │   └── param=1
+    └── expver=0002
+        └── param=2
+""")
+
+    assert q.axes() == q.all_unique_dim_coords()
+
+
+def test_dimensions_returns_set_of_dim_names() -> None:
+    """dimensions() returns the set of dimension names in the tree."""
+    q = Qube.from_ascii("""root
+└── class=od
+    └── expver=0001
+        └── param=1
+""")
+
+    dims = q.dimensions()
+    assert isinstance(dims, set)
+    assert dims == {"class", "expver", "param"}
+
+
+def test_copy_creates_independent_qube() -> None:
+    """copy.copy() should produce an independent clone."""
+    q = Qube.from_ascii("""root
+└── class=od
+    └── param=1
+""")
+
+    q2 = copy.copy(q)
+    assert q2.to_ascii() == q.to_ascii()
+
+    # Mutating the copy should not affect the original
+    q2.append_datacube({"class": "rd", "param": "2"}, ["class", "param"])
+    assert "class=rd" not in q.to_ascii()
+    assert "class=rd" in q2.to_ascii()
+
+
+def test_deepcopy_creates_independent_qube() -> None:
+    """copy.deepcopy() should produce an independent clone."""
+    q = Qube.from_ascii("""root
+└── class=od
+    └── param=1
+""")
+
+    q2 = copy.deepcopy(q)
+    assert q2.to_ascii() == q.to_ascii()
+
+    q2.append_datacube({"class": "rd", "param": "2"}, ["class", "param"])
+    assert "class=rd" not in q.to_ascii()
+
+
+def test_or_operator_returns_merged_qube() -> None:
+    """The | operator should return a new merged Qube without mutating either operand."""
+    a = Qube.from_ascii("""root
+└── class=od
+    └── param=1
+""")
+    b = Qube.from_ascii("""root
+└── class=rd
+    └── param=2
+""")
+
+    merged = a | b
+
+    assert "class=od" in merged.to_ascii()
+    assert "class=rd" in merged.to_ascii()
+
+    # Originals unchanged
+    assert "class=rd" not in a.to_ascii()
+    assert "class=od" not in b.to_ascii()
+
+
+def test_drop_returns_new_qube() -> None:
+    """drop() should return a new Qube, not mutate in place."""
+    q = Qube.from_ascii("""root
+└── class=1
+    └── expver=0001
+        └── param=1
+""")
+
+    dropped = q.drop(["expver"])
+
+    # Original unchanged
+    assert "expver=0001" in q.to_ascii()
+    # Dropped version has no expver
+    assert "expver" not in dropped.to_ascii()
+    assert "param=1" in dropped.to_ascii()
+
+
+def test_squeeze_returns_new_qube() -> None:
+    """squeeze() should return a new Qube, not mutate in place."""
+    q = Qube.from_ascii("""root
+└── class=1
+    └── expver=0001
+        └── param=1/2
+""")
+
+    squeezed = q.squeeze()
+
+    # Original unchanged
+    assert "class=1" in q.to_ascii()
+    assert "expver=0001" in q.to_ascii()
+    # Squeezed version drops single-value dims
+    assert "class" not in squeezed.to_ascii()
+    assert "expver" not in squeezed.to_ascii()
+    assert "param=1/2" in squeezed.to_ascii()
+
+
+def test_repr() -> None:
+    """__repr__ should return Qube(root_id=...)."""
+    q = Qube()
+    assert repr(q).startswith("Qube(root_id=")

--- a/py_qubed/tests/test_qubed_initialisation.py
+++ b/py_qubed/tests/test_qubed_initialisation.py
@@ -1,0 +1,6 @@
+from qubed import Qube
+
+
+def test_create_empty_qube() -> None:
+    qube = Qube.empty()
+    assert qube.is_empty()

--- a/py_qubed/tests/test_select_api.py
+++ b/py_qubed/tests/test_select_api.py
@@ -19,7 +19,7 @@ def test_select_1():
         ├── param=1
         └── param=2"""
 
-    q = qubed.PyQube.from_ascii(input_qube)
+    q = qubed.Qube.from_ascii(input_qube)
 
     selected = q.select({"class": [1]}, None, None)
 
@@ -32,7 +32,7 @@ def test_select_1():
         ├── param=1
         └── param=2"""
 
-    assert selected.to_ascii() == qubed.PyQube.from_ascii(expected).to_ascii()
+    assert selected.to_ascii() == qubed.Qube.from_ascii(expected).to_ascii()
 
 
 def test_select_2():
@@ -53,7 +53,7 @@ def test_select_2():
         ├── param=1
         └── param=2"""
 
-    q = qubed.PyQube.from_ascii(input_qube)
+    q = qubed.Qube.from_ascii(input_qube)
 
     selected = q.select({"class": [1], "param": [1]}, None, None)
 
@@ -64,7 +64,7 @@ def test_select_2():
     └── expver=0002
         └── param=1"""
 
-    assert selected.to_ascii() == qubed.PyQube.from_ascii(expected).to_ascii()
+    assert selected.to_ascii() == qubed.Qube.from_ascii(expected).to_ascii()
 
 
 def test_select_3():
@@ -85,7 +85,7 @@ def test_select_3():
         ├── param=1
         └── param=2"""
 
-    q = qubed.PyQube.from_ascii(input_qube)
+    q = qubed.Qube.from_ascii(input_qube)
 
     selected = q.select({"expver": ["0001"]}, None, None)
 
@@ -100,7 +100,7 @@ def test_select_3():
         ├── param=2
         └── param=3"""
 
-    assert selected.to_ascii() == qubed.PyQube.from_ascii(expected).to_ascii()
+    assert selected.to_ascii() == qubed.Qube.from_ascii(expected).to_ascii()
 
 
 def test_all_unique_dim_coords():
@@ -121,7 +121,7 @@ def test_all_unique_dim_coords():
         ├── param=1
         └── param=2"""
 
-    q = qubed.PyQube.from_ascii(input_qube)
+    q = qubed.Qube.from_ascii(input_qube)
 
     dim_coords = q.all_unique_dim_coords()
 
@@ -139,13 +139,13 @@ def test_all_unique_dim_coords():
     assert isinstance(dim_coords["param"], list)
 
     # Check that coordinates contain expected values
-    assert "1" in dim_coords["class"]
-    assert "2" in dim_coords["class"]
+    assert 1 in dim_coords["class"]
+    assert 2 in dim_coords["class"]
     assert "0001" in dim_coords["expver"]
     assert "0002" in dim_coords["expver"]
-    assert "1" in dim_coords["param"]
-    assert "2" in dim_coords["param"]
-    assert "3" in dim_coords["param"]
+    assert 1 in dim_coords["param"]
+    assert 2 in dim_coords["param"]
+    assert 3 in dim_coords["param"]
 
 
 def test_compress():
@@ -166,7 +166,7 @@ def test_compress():
         ├── param=1
         └── param=2"""
 
-    q = qubed.PyQube.from_ascii(input_qube)
+    q = qubed.Qube.from_ascii(input_qube)
 
     # Get the ASCII representation before compression
     ascii_before = q.to_ascii()
@@ -191,7 +191,7 @@ def test_compress_2():
     └── expver=0002
         └── param=2"""
 
-    q = qubed.PyQube.from_ascii(input_qube)
+    q = qubed.Qube.from_ascii(input_qube)
 
     # Get the ASCII representation before compression
     ascii_before = q.to_ascii()
@@ -228,7 +228,7 @@ def test_select_multiple_values():
         ├── param=1
         └── param=2"""
 
-    q = qubed.PyQube.from_ascii(input_qube)
+    q = qubed.Qube.from_ascii(input_qube)
 
     # Select multiple values for the same key
     selected = q.select({"param": [1, 3]}, None, None)
@@ -246,7 +246,7 @@ def test_select_multiple_values():
     └── expver=0002
         └── param=1"""
 
-    assert selected.to_ascii() == qubed.PyQube.from_ascii(expected).to_ascii()
+    assert selected.to_ascii() == qubed.Qube.from_ascii(expected).to_ascii()
 
 
 def test_default():
@@ -268,7 +268,7 @@ def test_default():
         ├── param=1
         └── param=2"""
 
-    q = qubed.PyQube.from_ascii(input_qube)
+    q = qubed.Qube.from_ascii(input_qube)
 
     # Default mode: shows full subtree
     default_result = q.select({"class": [1]}, None, None)
@@ -283,8 +283,7 @@ def test_default():
         └── param=2"""
 
     assert (
-        default_result.to_ascii()
-        == qubed.PyQube.from_ascii(default_expected).to_ascii()
+        default_result.to_ascii() == qubed.Qube.from_ascii(default_expected).to_ascii()
     )
 
 
@@ -298,14 +297,14 @@ def test_drop():
         ├── param=1
         └── param=2"""
 
-    q = qubed.PyQube.from_ascii(input_qube)
-    q.drop(["expver"])
+    q = qubed.Qube.from_ascii(input_qube)
+    q = q.drop(["expver"])
 
     expected = r"""root
 └── class=1
     └── param=1/2"""
 
-    assert q.to_ascii() == qubed.PyQube.from_ascii(expected).to_ascii()
+    assert q.to_ascii() == qubed.Qube.from_ascii(expected).to_ascii()
 
 
 def test_squeeze():
@@ -318,15 +317,15 @@ def test_squeeze():
         ├── param=1
         └── param=2"""
 
-    q = qubed.PyQube.from_ascii(input_qube)
-    q.squeeze()
+    q = qubed.Qube.from_ascii(input_qube)
+    q = q.squeeze()
 
     # class has only one value (1), so it gets squeezed out
     expected = r"""root
 └── expver=0001/0002
     └── param=1/2"""
 
-    assert q.to_ascii() == qubed.PyQube.from_ascii(expected).to_ascii()
+    assert q.to_ascii() == qubed.Qube.from_ascii(expected).to_ascii()
 
 
 def test_select_drops_branches_without_matching_deep_key():
@@ -339,14 +338,14 @@ def test_select_drops_branches_without_matching_deep_key():
     ├── param=3
     └── param=4"""
 
-    q = qubed.PyQube.from_ascii(input_qube)
+    q = qubed.Qube.from_ascii(input_qube)
     selected = q.select({"param": [1]}, None, None)
 
     expected = r"""root
 └── expver=0001
     └── param=1"""
 
-    assert selected.to_ascii() == qubed.PyQube.from_ascii(expected).to_ascii(), (
+    assert selected.to_ascii() == qubed.Qube.from_ascii(expected).to_ascii(), (
         "expver=0002 (no param=1 descendants) should be absent from the result"
     )
 
@@ -366,7 +365,7 @@ def test_select_deep_key_multi_level_unselected_prefix():
         ├── param=5
         └── param=6"""
 
-    q = qubed.PyQube.from_ascii(input_qube)
+    q = qubed.Qube.from_ascii(input_qube)
     selected = q.select({"param": [1]}, None, None)
 
     expected = r"""root
@@ -374,6 +373,6 @@ def test_select_deep_key_multi_level_unselected_prefix():
     └── expver=0001
         └── param=1"""
 
-    assert selected.to_ascii() == qubed.PyQube.from_ascii(expected).to_ascii(), (
+    assert selected.to_ascii() == qubed.Qube.from_ascii(expected).to_ascii(), (
         "only class=1/expver=0001 contains param=1; all other branches must be pruned"
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,3 @@
-[project]
-name = "qubed"
-requires-python = ">=3.8"
-dependencies = []
-
 [tool.uv.workspace]
 members = [
     "py_qubed",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,3 @@
-[project]
-name = "qubed"
-version = "0.4.4"
-requires-python = ">=3.8"
-dependencies = []
-
 [tool.uv.workspace]
 members = [
     "py_qubed",

--- a/qubed/src/coordinates/mod.rs
+++ b/qubed/src/coordinates/mod.rs
@@ -54,14 +54,18 @@ impl Coordinates {
         let mut coords = Coordinates::Empty;
         let split: Vec<&str> = s.split('/').collect();
 
-        for part in split {
-            // Check for leading zeros to preserve formatting (e.g., "0001")
-            let has_leading_zero = part.len() > 1
-                && part.starts_with('0')
-                && part.chars().nth(1).map_or(false, |c| c.is_ascii_digit());
+        // When multiple values are present, ensure consistent typing:
+        // if all parse as integers but some have leading zeros, keep all as strings.
+        let all_int = split.iter().all(|p| p.parse::<i32>().is_ok());
+        let any_leading_zero = split.iter().any(|p| {
+            p.len() > 1
+                && p.starts_with('0')
+                && p.chars().nth(1).map_or(false, |c| c.is_ascii_digit())
+        });
+        let force_strings = all_int && any_leading_zero;
 
-            if has_leading_zero {
-                // Preserve as string to keep formatting
+        for part in split {
+            if force_strings {
                 coords.append(part.to_string());
             } else if let Ok(int_val) = part.parse::<i32>() {
                 coords.append(int_val);
@@ -81,8 +85,25 @@ impl Coordinates {
             Coordinates::Floats(floats) => floats.to_string(),
             Coordinates::DateTimes(datetimes) => datetimes.to_string(),
             Coordinates::Strings(strings) => strings.to_string(),
-            Coordinates::Mixed(_) => {
-                todo!()
+            Coordinates::Mixed(mixed) => {
+                let mut parts: Vec<String> = Vec::new();
+                let ints_str = mixed.integers.to_string();
+                if !ints_str.is_empty() {
+                    parts.push(ints_str);
+                }
+                let floats_str = mixed.floats.to_string();
+                if !floats_str.is_empty() {
+                    parts.push(floats_str);
+                }
+                let strings_str = mixed.strings.to_string();
+                if !strings_str.is_empty() {
+                    parts.push(strings_str);
+                }
+                let datetimes_str = mixed.datetimes.to_string();
+                if !datetimes_str.is_empty() {
+                    parts.push(datetimes_str);
+                }
+                parts.join("/")
             }
         }
     }
@@ -157,27 +178,52 @@ impl Coordinates {
         self
     }
 
+    fn type_name(&self) -> &'static str {
+        match self {
+            Coordinates::Empty => "Empty",
+            Coordinates::Integers(_) => "Integers",
+            Coordinates::Floats(_) => "Floats",
+            Coordinates::Strings(_) => "Strings",
+            Coordinates::DateTimes(_) => "DateTimes",
+            Coordinates::Mixed(_) => "Mixed",
+        }
+    }
+
     pub fn intersect(&self, _other: &Coordinates) -> IntersectionResult<Coordinates> {
         match (self, _other) {
             (Coordinates::Integers(ints_a), Coordinates::Integers(ints_b)) => {
                 let result = ints_a.intersect(ints_b);
                 IntersectionResult {
-                    intersection: Coordinates::Integers(result.intersection),
-                    only_a: Coordinates::Integers(result.only_a),
-                    only_b: Coordinates::Integers(result.only_b),
+                    intersection: wrap_ints(result.intersection),
+                    only_a: wrap_ints(result.only_a),
+                    only_b: wrap_ints(result.only_b),
                 }
             }
             (Coordinates::Strings(strs_a), Coordinates::Strings(strs_b)) => {
                 let result = strs_a.intersect(strs_b);
                 IntersectionResult {
-                    intersection: Coordinates::Strings(result.intersection),
-                    only_a: Coordinates::Strings(result.only_a),
-                    only_b: Coordinates::Strings(result.only_b),
+                    intersection: wrap_strs(result.intersection),
+                    only_a: wrap_strs(result.only_a),
+                    only_b: wrap_strs(result.only_b),
                 }
             }
-            _ => {
-                unimplemented!("Intersection not implemented for these coordinate types");
-            }
+            // Empty on either side: intersection is empty; the non-empty side goes to its slot.
+            (Coordinates::Empty, _) => IntersectionResult {
+                intersection: Coordinates::Empty,
+                only_a: Coordinates::Empty,
+                only_b: _other.clone(),
+            },
+            (_, Coordinates::Empty) => IntersectionResult {
+                intersection: Coordinates::Empty,
+                only_a: self.clone(),
+                only_b: Coordinates::Empty,
+            },
+            // Cross-type: no values can be shared, so intersection is empty.
+            _ => IntersectionResult {
+                intersection: Coordinates::Empty,
+                only_a: self.clone(),
+                only_b: _other.clone(),
+            },
         }
     }
 
@@ -217,6 +263,14 @@ impl Default for Coordinates {
 }
 
 // ------------- Intersection ------------------
+
+fn wrap_ints(c: integers::IntegerCoordinates) -> Coordinates {
+    if c.len() == 0 { Coordinates::Empty } else { Coordinates::Integers(c) }
+}
+
+fn wrap_strs(c: strings::StringCoordinates) -> Coordinates {
+    if c.len() == 0 { Coordinates::Empty } else { Coordinates::Strings(c) }
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct IntersectionResult<T> {
@@ -507,5 +561,112 @@ impl Coordinates {
             Value::String(s) => Ok(Coordinates::from_string(s)),
             _ => Err("Unsupported coords JSON value".to_string()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ints(vals: &[i32]) -> Coordinates {
+        let mut c = Coordinates::Empty;
+        for &v in vals {
+            c.append(v);
+        }
+        c
+    }
+
+    fn strs(vals: &[&str]) -> Coordinates {
+        let mut c = Coordinates::Empty;
+        for &v in vals {
+            c.append(v.to_string());
+        }
+        c
+    }
+
+    // ---- Integers ∩ Integers ------------------------------------------------
+
+    #[test]
+    fn intersect_integers_overlapping() {
+        let result = ints(&[1, 2, 3]).intersect(&ints(&[2, 3, 4]));
+        assert_eq!(result.intersection, ints(&[2, 3]));
+        assert_eq!(result.only_a, ints(&[1]));
+        assert_eq!(result.only_b, ints(&[4]));
+    }
+
+    #[test]
+    fn intersect_integers_disjoint() {
+        let result = ints(&[1, 2]).intersect(&ints(&[3, 4]));
+        assert_eq!(result.intersection, Coordinates::Empty);
+        assert_eq!(result.only_a, ints(&[1, 2]));
+        assert_eq!(result.only_b, ints(&[3, 4]));
+    }
+
+    #[test]
+    fn intersect_integers_identical() {
+        let result = ints(&[5, 10]).intersect(&ints(&[5, 10]));
+        assert_eq!(result.intersection, ints(&[5, 10]));
+        assert_eq!(result.only_a, Coordinates::Empty);
+        assert_eq!(result.only_b, Coordinates::Empty);
+    }
+
+    // ---- Strings ∩ Strings --------------------------------------------------
+
+    #[test]
+    fn intersect_strings_overlapping() {
+        let result = strs(&["a", "b", "c"]).intersect(&strs(&["b", "c", "d"]));
+        assert_eq!(result.intersection, strs(&["b", "c"]));
+        assert_eq!(result.only_a, strs(&["a"]));
+        assert_eq!(result.only_b, strs(&["d"]));
+    }
+
+    #[test]
+    fn intersect_strings_disjoint() {
+        let result = strs(&["pf"]).intersect(&strs(&["fc"]));
+        assert_eq!(result.intersection, Coordinates::Empty);
+        assert_eq!(result.only_a, strs(&["pf"]));
+        assert_eq!(result.only_b, strs(&["fc"]));
+    }
+
+    #[test]
+    fn intersect_strings_identical() {
+        let result = strs(&["od"]).intersect(&strs(&["od"]));
+        assert_eq!(result.intersection, strs(&["od"]));
+        assert_eq!(result.only_a, Coordinates::Empty);
+        assert_eq!(result.only_b, Coordinates::Empty);
+    }
+
+    // ---- Empty cases --------------------------------------------------------
+
+    #[test]
+    fn intersect_empty_with_integers() {
+        let result = Coordinates::Empty.intersect(&ints(&[1, 2, 3]));
+        assert_eq!(result.intersection, Coordinates::Empty);
+        assert_eq!(result.only_a, Coordinates::Empty);
+        assert_eq!(result.only_b, ints(&[1, 2, 3]));
+    }
+
+    #[test]
+    fn intersect_integers_with_empty() {
+        let result = ints(&[1, 2, 3]).intersect(&Coordinates::Empty);
+        assert_eq!(result.intersection, Coordinates::Empty);
+        assert_eq!(result.only_a, ints(&[1, 2, 3]));
+        assert_eq!(result.only_b, Coordinates::Empty);
+    }
+
+    #[test]
+    fn intersect_empty_with_strings() {
+        let result = Coordinates::Empty.intersect(&strs(&["pf"]));
+        assert_eq!(result.intersection, Coordinates::Empty);
+        assert_eq!(result.only_a, Coordinates::Empty);
+        assert_eq!(result.only_b, strs(&["pf"]));
+    }
+
+    #[test]
+    fn intersect_empty_with_empty() {
+        let result = Coordinates::Empty.intersect(&Coordinates::Empty);
+        assert_eq!(result.intersection, Coordinates::Empty);
+        assert_eq!(result.only_a, Coordinates::Empty);
+        assert_eq!(result.only_b, Coordinates::Empty);
     }
 }

--- a/qubed/src/coordinates/mod.rs
+++ b/qubed/src/coordinates/mod.rs
@@ -669,4 +669,16 @@ mod tests {
         assert_eq!(result.only_a, Coordinates::Empty);
         assert_eq!(result.only_b, Coordinates::Empty);
     }
+
+    #[test]
+    fn from_string_splits_on_slash() {
+        let c = Coordinates::from_string("1/2/3");
+        assert_eq!(c, ints(&[1, 2, 3]));
+
+        let c = Coordinates::from_string("od/rd");
+        assert_eq!(c, strs(&["od", "rd"]));
+
+        let c = Coordinates::from_string("single");
+        assert_eq!(c, strs(&["single"]));
+    }
 }

--- a/qubed/src/coordinates/ops.rs
+++ b/qubed/src/coordinates/ops.rs
@@ -1,5 +1,8 @@
 use crate::Coordinates;
 use crate::coordinates::CoordinateTypes;
+use crate::coordinates::integers::IntegerCoordinates;
+use crate::coordinates::strings::StringCoordinates;
+use crate::utils::tiny_ordered_set::TinyOrderedSet;
 use chrono::NaiveDateTime;
 
 impl From<NaiveDateTime> for CoordinateTypes {
@@ -24,6 +27,16 @@ impl Coordinates {
             Coordinates::Integers(new_ints) => match self {
                 Coordinates::Integers(ints) => {
                     ints.extend(new_ints);
+                }
+                Coordinates::Strings(strings) => {
+                    // Try to coerce all strings to integers
+                    if let Some(converted) = try_strings_to_integers(strings) {
+                        let mut merged = converted;
+                        merged.extend(new_ints);
+                        *self = Coordinates::Integers(merged);
+                    } else {
+                        self.convert_to_mixed().extend(new_coords);
+                    }
                 }
                 Coordinates::Mixed(mixed) => {
                     mixed.integers.extend(new_ints);
@@ -52,6 +65,14 @@ impl Coordinates {
             Coordinates::Strings(new_strings) => match self {
                 Coordinates::Strings(strings) => {
                     strings.extend(new_strings);
+                }
+                Coordinates::Integers(ints) => {
+                    // Try to coerce all new strings to integers
+                    if let Some(converted) = try_strings_to_integers(new_strings) {
+                        ints.extend(&converted);
+                    } else {
+                        self.convert_to_mixed().extend(new_coords);
+                    }
                 }
                 Coordinates::Mixed(mixed) => {
                     mixed.strings.extend(new_strings);
@@ -239,5 +260,33 @@ impl From<f64> for CoordinateTypes {
 impl From<String> for CoordinateTypes {
     fn from(val: String) -> Self {
         CoordinateTypes::String(val)
+    }
+}
+
+/// Attempt to convert all values in a StringCoordinates to integers.
+/// Returns Some(IntegerCoordinates) if every string parses as i32 and none
+/// have leading zeros (which would lose formatting information), None otherwise.
+fn try_strings_to_integers(strings: &StringCoordinates) -> Option<IntegerCoordinates> {
+    match strings {
+        StringCoordinates::Set(set) => {
+            let mut int_set: TinyOrderedSet<i32, 6> = TinyOrderedSet::new();
+            for s in set.iter() {
+                let s_str = s.to_string();
+                // Reject strings with leading zeros to preserve formatting
+                if s_str.len() > 1
+                    && s_str.starts_with('0')
+                    && s_str.chars().nth(1).map_or(false, |c| c.is_ascii_digit())
+                {
+                    return None;
+                }
+                match s_str.parse::<i32>() {
+                    Ok(val) => {
+                        int_set.insert(val);
+                    }
+                    Err(_) => return None,
+                }
+            }
+            Some(IntegerCoordinates::Set(int_set))
+        }
     }
 }

--- a/qubed/src/datacube.rs
+++ b/qubed/src/datacube.rs
@@ -49,6 +49,12 @@ impl Qube {
         datacubes
     }
 
+    /// Build a Qube from a single Datacube.
+    ///
+    /// If `order` is provided, dimensions are nested in that order. Any dimensions
+    /// not listed in `order` are appended in sorted (alphabetical) order for
+    /// deterministic tree structure. When `order` is `None`, all dimensions are
+    /// sorted alphabetically.
     pub fn from_datacube(datacube: &Datacube, order: Option<&[String]>) -> Self {
         let mut qube = Qube::new();
         let mut parent = qube.root();
@@ -64,13 +70,18 @@ impl Qube {
             }
         }
 
-        // Create remaining dimensions
-        for (dim, coords) in datacube.coordinates.iter() {
-            if qube.dimension(&dim).is_some() {
-                continue;
-            }
+        // Create remaining dimensions in sorted order for deterministic tree structure
+        let mut remaining: Vec<&String> = datacube
+            .coordinates
+            .keys()
+            .filter(|dim| qube.dimension(dim).is_none())
+            .collect();
+        remaining.sort();
+
+        for dim in remaining {
+            let coords = &datacube.coordinates[dim];
             parent = qube
-                .get_or_create_child(&dim, parent, Some(coords.clone()))
+                .get_or_create_child(dim, parent, Some(coords.clone()))
                 .expect("Failed to create dimension");
         }
 
@@ -132,3 +143,177 @@ impl Qube {
         // }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Coordinates;
+
+    fn dc(pairs: &[(&str, &str)]) -> Datacube {
+        let mut d = Datacube::new();
+        for &(k, v) in pairs {
+            d.add_coordinate(k, Coordinates::from_string(v));
+        }
+        d
+    }
+
+    /// Helper to extract the dimension ordering from a Qube's ASCII output.
+    /// Returns the dimensions in the order they appear top-to-bottom (root→leaf).
+    fn dimension_order(qube: &Qube) -> Vec<String> {
+        let ascii = qube.to_ascii();
+        let mut dims = Vec::new();
+        for line in ascii.lines() {
+            if let Some(eq_pos) = line.find('=') {
+                // Walk backward from '=' to find the start of the dim name
+                let before_eq = &line[..eq_pos];
+                let dim_start = before_eq
+                    .rfind(|c: char| !c.is_alphanumeric() && c != '_')
+                    .map(|i| i + 1)
+                    .unwrap_or(0);
+                let dim = &before_eq[dim_start..];
+                if !dim.is_empty() && !dims.contains(&dim.to_string()) {
+                    dims.push(dim.to_string());
+                }
+            }
+        }
+        dims
+    }
+
+    #[test]
+    fn from_datacube_with_explicit_order() {
+        let datacube = dc(&[("step", "0/6"), ("class", "od"), ("time", "0000")]);
+        let order: Vec<String> =
+            vec!["class", "time", "step"].into_iter().map(String::from).collect();
+        let qube = Qube::from_datacube(&datacube, Some(&order));
+
+        let dims = dimension_order(&qube);
+        assert_eq!(dims, vec!["class", "time", "step"]);
+    }
+
+    #[test]
+    fn from_datacube_no_order_falls_back_to_alphabetical() {
+        let datacube = dc(&[("step", "0/6"), ("class", "od"), ("time", "0000")]);
+        let qube = Qube::from_datacube(&datacube, None);
+
+        let dims = dimension_order(&qube);
+        assert_eq!(dims, vec!["class", "step", "time"]);
+    }
+
+    #[test]
+    fn from_datacube_partial_order_appends_remaining_alphabetically() {
+        let datacube = dc(&[
+            ("step", "0/6"),
+            ("class", "od"),
+            ("time", "0000"),
+            ("param", "t"),
+        ]);
+        // Only specify first two dims; step and param should be appended alphabetically
+        let order: Vec<String> = vec!["time", "class"].into_iter().map(String::from).collect();
+        let qube = Qube::from_datacube(&datacube, Some(&order));
+
+        let dims = dimension_order(&qube);
+        assert_eq!(dims, vec!["time", "class", "param", "step"]);
+    }
+
+    #[test]
+    fn union_preserves_time_split_when_subtrees_differ() {
+        // Simulates the ifs-ens case: two datacubes with time=0000/1200 vs time=0600/1800
+        // with DIFFERENT step ranges underneath. They must not merge because the subtrees
+        // are structurally different.
+        let order: Vec<String> = vec!["domain", "time", "type", "stream", "step", "param"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+
+        let dc_a = dc(&[
+            ("domain", "g"),
+            ("time", "0000/1200"),
+            ("type", "fc"),
+            ("stream", "oper"),
+            ("step", "0/6/12/150/156"),
+            ("param", "t/u"),
+        ]);
+        let dc_b = dc(&[
+            ("domain", "g"),
+            ("time", "0600/1800"),
+            ("type", "fc"),
+            ("stream", "oper"),
+            ("step", "0/6/12"),
+            ("param", "t/u"),
+        ]);
+
+        let mut qube_a = Qube::from_datacube(&dc_a, Some(&order));
+        let mut qube_b = Qube::from_datacube(&dc_b, Some(&order));
+        qube_a.append(&mut qube_b);
+
+        let ascii = qube_a.to_ascii();
+        // time=0000/1200 and time=0600/1800 should be separate branches because
+        // the step ranges below them differ
+        assert!(
+            ascii.contains("time=0000/1200"),
+            "time=0000/1200 branch missing:\n{ascii}"
+        );
+        assert!(
+            ascii.contains("time=0600/1800"),
+            "time=0600/1800 branch missing:\n{ascii}"
+        );
+    }
+
+    #[test]
+    fn union_merges_time_when_subtrees_identical() {
+        // When subtrees below different time values are structurally identical,
+        // compress correctly merges them into a single node.
+        let order: Vec<String> = vec!["domain", "time", "type", "step", "param"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+
+        let dc_a = dc(&[
+            ("domain", "g"),
+            ("time", "0000/1200"),
+            ("type", "fc"),
+            ("step", "0/6/12"),
+            ("param", "t/u"),
+        ]);
+        let dc_b = dc(&[
+            ("domain", "g"),
+            ("time", "0600/1800"),
+            ("type", "fc"),
+            ("step", "0/6/12"),
+            ("param", "t/u"),
+        ]);
+
+        let mut qube_a = Qube::from_datacube(&dc_a, Some(&order));
+        let mut qube_b = Qube::from_datacube(&dc_b, Some(&order));
+        qube_a.append(&mut qube_b);
+
+        let ascii = qube_a.to_ascii();
+        // All four times should be merged since subtrees are identical
+        assert!(
+            ascii.contains("time=0000/0600/1200/1800"),
+            "times should be merged when subtrees match:\n{ascii}"
+        );
+    }
+
+    #[test]
+    fn from_datacube_string_coords_not_parsed_as_integers() {
+        // "1200" as a string should stay as Strings, not become Integer(1200)
+        let mut datacube = Datacube::new();
+        let mut coords = Coordinates::new();
+        coords.append("1200".to_string());
+        datacube.add_coordinate("time", coords);
+
+        let mut coords2 = Coordinates::new();
+        coords2.append("0000".to_string());
+        coords2.append("1200".to_string());
+
+        // Extending with the same type (Strings) should work without creating Mixed
+        coords2.extend(&datacube.coordinates()["time"]);
+        assert!(
+            !matches!(coords2, Coordinates::Mixed(_)),
+            "extending Strings with Strings should not produce Mixed: {:?}",
+            coords2
+        );
+    }
+}
+

--- a/qubed/src/datacube.rs
+++ b/qubed/src/datacube.rs
@@ -71,11 +71,8 @@ impl Qube {
         }
 
         // Create remaining dimensions in sorted order for deterministic tree structure
-        let mut remaining: Vec<&String> = datacube
-            .coordinates
-            .keys()
-            .filter(|dim| qube.dimension(dim).is_none())
-            .collect();
+        let mut remaining: Vec<&String> =
+            datacube.coordinates.keys().filter(|dim| qube.dimension(dim).is_none()).collect();
         remaining.sort();
 
         for dim in remaining {
@@ -201,12 +198,7 @@ mod tests {
 
     #[test]
     fn from_datacube_partial_order_appends_remaining_alphabetically() {
-        let datacube = dc(&[
-            ("step", "0/6"),
-            ("class", "od"),
-            ("time", "0000"),
-            ("param", "t"),
-        ]);
+        let datacube = dc(&[("step", "0/6"), ("class", "od"), ("time", "0000"), ("param", "t")]);
         // Only specify first two dims; step and param should be appended alphabetically
         let order: Vec<String> = vec!["time", "class"].into_iter().map(String::from).collect();
         let qube = Qube::from_datacube(&datacube, Some(&order));
@@ -249,24 +241,16 @@ mod tests {
         let ascii = qube_a.to_ascii();
         // time=0000/1200 and time=0600/1800 should be separate branches because
         // the step ranges below them differ
-        assert!(
-            ascii.contains("time=0000/1200"),
-            "time=0000/1200 branch missing:\n{ascii}"
-        );
-        assert!(
-            ascii.contains("time=0600/1800"),
-            "time=0600/1800 branch missing:\n{ascii}"
-        );
+        assert!(ascii.contains("time=0000/1200"), "time=0000/1200 branch missing:\n{ascii}");
+        assert!(ascii.contains("time=0600/1800"), "time=0600/1800 branch missing:\n{ascii}");
     }
 
     #[test]
     fn union_merges_time_when_subtrees_identical() {
         // When subtrees below different time values are structurally identical,
         // compress correctly merges them into a single node.
-        let order: Vec<String> = vec!["domain", "time", "type", "step", "param"]
-            .into_iter()
-            .map(String::from)
-            .collect();
+        let order: Vec<String> =
+            vec!["domain", "time", "type", "step", "param"].into_iter().map(String::from).collect();
 
         let dc_a = dc(&[
             ("domain", "g"),
@@ -316,4 +300,3 @@ mod tests {
         );
     }
 }
-

--- a/qubed/src/merge.rs
+++ b/qubed/src/merge.rs
@@ -233,8 +233,8 @@ impl Qube {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::datacube::Datacube;
     use crate::Coordinates;
+    use crate::datacube::Datacube;
 
     fn dc(pairs: &[(&str, &str)]) -> Datacube {
         let mut d = Datacube::new();

--- a/qubed/src/merge.rs
+++ b/qubed/src/merge.rs
@@ -1,12 +1,33 @@
 use crate::qube::Dimension;
 use crate::{NodeIdx, Qube};
 use std::collections::HashMap;
-use std::time::Instant;
 
 impl Qube {
+    /// Build a mapping from `other`'s dimension IDs to `self`'s dimension IDs
+    /// by interning all of `other`'s dimension names into `self`'s key_store.
+    /// This allows us to compare dimensions by ID rather than string in the merge loop.
+    fn build_dim_translation(&mut self, other: &Qube) -> HashMap<Dimension, Dimension> {
+        let mut map = HashMap::new();
+        for other_dim in other.all_dim_ids() {
+            if let Some(name) = other.dimension_str(&other_dim) {
+                let self_dim = self.get_or_intern_dim(name);
+                map.insert(other_dim, self_dim);
+            }
+        }
+        map
+    }
+
     /// Performs a union operation between two nodes in two different Qubes.
-    fn node_merge(&mut self, other: &mut Qube, self_id: NodeIdx, other_id: NodeIdx) -> NodeIdx {
-        // Group the children of both nodes into groups according to their associated dimensions.
+    fn node_merge(
+        &mut self,
+        other: &mut Qube,
+        self_id: NodeIdx,
+        other_id: NodeIdx,
+        dim_map: &HashMap<Dimension, Dimension>,
+    ) -> NodeIdx {
+        // Group children by dimension, using self's dimension IDs (via the translation map)
+        // so that same-named dimensions from both qubes are matched correctly regardless of
+        // interner ordering.
         let self_children = {
             let node = self.node_ref(self_id).unwrap();
             node.children().clone()
@@ -17,26 +38,43 @@ impl Qube {
             node.children().clone()
         };
 
-        // Create a map of dimensions to (self_children, other_children).
         let mut dim_child_map: HashMap<Dimension, (Vec<NodeIdx>, Vec<NodeIdx>)> = HashMap::new();
 
         for (dim, self_kids) in self_children {
             dim_child_map.entry(dim).or_default().0.extend(self_kids);
         }
         for (dim, other_kids) in other_children {
-            dim_child_map.entry(dim).or_default().1.extend(other_kids);
+            // Translate other's dimension ID to self's namespace
+            let self_dim = dim_map.get(&dim).copied().unwrap_or(dim);
+            dim_child_map.entry(self_dim).or_default().1.extend(other_kids);
         }
 
         // For each dimension, perform an internal set operation on the groups.
-        let dims: Vec<_> = dim_child_map.keys().copied().collect();
+        let dims: Vec<Dimension> = dim_child_map.keys().copied().collect();
 
         for dim in dims {
             let (these_kids, those_kids) = {
                 let entry = dim_child_map.entry(dim).or_default();
-                (&entry.0, &entry.1)
+                (entry.0.clone(), entry.1.clone())
             };
 
-            let _new_children = self.internal_set_operation(other, these_kids, those_kids);
+            if these_kids.is_empty() {
+                // Dimension exists only in `other`: copy every node (and its subtree) into self.
+                for other_node in those_kids {
+                    let (dim_str, coords) = {
+                        let n = other.node_ref(other_node).unwrap();
+                        let d = other.dimension_str(n.dim()).unwrap().to_owned();
+                        let c = n.coords().clone();
+                        (d, c)
+                    };
+                    let new_child =
+                        self.get_or_create_child(&dim_str, self_id, Some(coords)).unwrap();
+                    self.copy_subtree(other, other_node, new_child);
+                }
+            } else {
+                let _new_children =
+                    self.internal_set_operation(other, &these_kids, &those_kids, dim_map);
+            }
         }
 
         return self.root();
@@ -46,8 +84,9 @@ impl Qube {
     fn internal_set_operation(
         &mut self,
         other: &mut Qube,
-        self_ids: &Vec<NodeIdx>,
-        other_ids: &Vec<NodeIdx>,
+        self_ids: &[NodeIdx],
+        other_ids: &[NodeIdx],
+        dim_map: &HashMap<Dimension, Dimension>,
     ) -> Option<Vec<NodeIdx>> {
         let mut return_vec = Vec::new();
 
@@ -106,7 +145,7 @@ impl Qube {
                         other.copy_branch(*other_node, new_node_b);
                     }
 
-                    let _nested_result = self.node_merge(other, new_node_a, new_node_b);
+                    let _nested_result = self.node_merge(other, new_node_a, new_node_b, dim_map);
                 }
 
                 // If there are values only in self, update the coordinates of the current node.
@@ -152,9 +191,13 @@ impl Qube {
             return;
         }
 
+        // Pre-intern all of other's dimension names into self's key_store so we can
+        // compare dimensions by ID rather than string throughout the recursive merge.
+        let dim_map = self.build_dim_translation(other);
+
         let self_root_id = self.root();
         let other_root_id = other.root();
-        self.node_merge(other, self_root_id, other_root_id);
+        self.node_merge(other, self_root_id, other_root_id, &dim_map);
         self.compress();
         // Clear the other Qube
         *other = Qube::new();
@@ -164,11 +207,14 @@ impl Qube {
     pub fn append_many(&mut self, others: &mut Vec<Qube>) {
         let others_len = others.len();
         for (i, other) in others.iter_mut().enumerate() {
+            // Build translation map for each other qube
+            let dim_map = self.build_dim_translation(other);
+
             let self_root_id = self.root();
             let other_root_id = other.root();
 
             // Perform the union with the current Qube
-            self.node_merge(other, self_root_id, other_root_id);
+            self.node_merge(other, self_root_id, other_root_id, &dim_map);
 
             // Print progress update
             println!("Union completed for Qube {}/{}", i + 1, others_len);
@@ -181,5 +227,56 @@ impl Qube {
         }
         // Final compression after all unions are complete
         self.compress();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::datacube::Datacube;
+    use crate::Coordinates;
+
+    fn dc(pairs: &[(&str, &str)]) -> Datacube {
+        let mut d = Datacube::new();
+        for &(k, v) in pairs {
+            d.add_coordinate(k, Coordinates::from_string(v));
+        }
+        d
+    }
+
+    /// Appending two Qubes whose dimensions were interned in a different order
+    /// must not cross-intersect coordinates from different dimension names.
+    /// Before the fix, the shared integer dimension ID caused e.g. `number` coords
+    /// to be intersected against `time` coords, producing a panic.
+    #[test]
+    fn append_qubes_with_different_dimension_interning_order() {
+        // First Qube: dimensions added in order a, b, c
+        let mut q1 = Qube::from_datacube(&dc(&[("a", "1"), ("b", "x"), ("c", "10")]), None);
+
+        // Second Qube: dimensions added in order c, b, a — interner assigns IDs in the opposite
+        // order, so `a` in q2 gets the same integer ID as `c` in q1.
+        let mut q2 = Qube::from_datacube(&dc(&[("c", "20"), ("b", "y"), ("a", "2")]), None);
+
+        // Must not panic.
+        q1.append(&mut q2);
+
+        let ascii = q1.to_ascii();
+        assert!(ascii.contains("a=1") || ascii.contains("a=2"), "a values lost: {ascii}");
+        assert!(ascii.contains("b=x") || ascii.contains("b=y"), "b values lost: {ascii}");
+        assert!(ascii.contains("c=10") || ascii.contains("c=20"), "c values lost: {ascii}");
+    }
+
+    #[test]
+    fn append_qubes_all_shared_dimensions_merged() {
+        let mut q1 = Qube::from_datacube(&dc(&[("class", "od"), ("step", "0/6/12")]), None);
+        let mut q2 = Qube::from_datacube(&dc(&[("class", "od"), ("step", "18/24")]), None);
+
+        q1.append(&mut q2);
+
+        let coords = q1.all_unique_dim_coords();
+        let steps: std::collections::BTreeSet<String> =
+            coords["step"].to_string().split('/').map(|s| s.to_owned()).collect();
+
+        assert_eq!(steps, ["0", "12", "18", "24", "6"].iter().map(|s| s.to_string()).collect());
     }
 }

--- a/qubed/src/qube.rs
+++ b/qubed/src/qube.rs
@@ -391,6 +391,18 @@ impl Qube {
         self.drop(to_drop)
     }
 
+    /// Wrap the entire tree under a new parent node with the given dimension and coordinates.
+    /// Returns a new Qube where root -> new_node -> (original root's children).
+    pub fn prepend(&self, dim: &str, coords: Coordinates) -> Self {
+        let mut new_qube = Qube::new();
+        let new_root = new_qube.root();
+        let wrapper_node = new_qube
+            .get_or_create_child(dim, new_root, Some(coords))
+            .expect("Failed to create prepend node");
+        new_qube.copy_subtree(self, self.root(), wrapper_node);
+        new_qube
+    }
+
     pub fn dimension(&self, dim_str: &str) -> Option<Dimension> {
         self.key_store.get(dim_str).map(Dimension)
     }

--- a/qubed/src/qube.rs
+++ b/qubed/src/qube.rs
@@ -362,8 +362,7 @@ impl Qube {
                                 .map(|s| to_drop.contains(s))
                                 .unwrap_or(false);
                             if gc_should_drop {
-                                next_pending
-                                    .extend(self.splice_out_node(gc_id, node_id)?);
+                                next_pending.extend(self.splice_out_node(gc_id, node_id)?);
                             } else {
                                 self.drop_recurse(gc_id, to_drop)?;
                             }

--- a/qubed/src/qube.rs
+++ b/qubed/src/qube.rs
@@ -31,7 +31,19 @@ pub(crate) struct Node {
     children: BTreeMap<Dimension, TinyVec<NodeIdx, 4>>,
 }
 
-#[derive(Debug)]
+impl Clone for Node {
+    fn clone(&self) -> Self {
+        Node {
+            dim: self.dim,
+            structural_hash: AtomicU64::new(self.structural_hash.load(Ordering::Relaxed)),
+            coords: self.coords.clone(),
+            parent: self.parent,
+            children: self.children.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct Qube {
     nodes: SlotMap<NodeIdx, Node>,
     root_id: NodeIdx,
@@ -195,22 +207,31 @@ impl Qube {
     }
 
     pub fn all_unique_dim_coords(&mut self) -> BTreeMap<String, Coordinates> {
-        // TODO
         let mut map: BTreeMap<String, Coordinates> = BTreeMap::new();
 
         for (_id, node) in self.nodes.iter() {
             if let Some(dim_str) = self.dimension_str(&node.dim) {
                 let coords = node.coords.clone();
                 if coords.is_empty() {
-                    continue; // Skip empty coordinates
+                    continue;
                 }
-                // if there is no entry in map for this dimension, just fill it in with coords, otherwise extend the current entry with coords
                 map.entry(dim_str.to_string())
                     .and_modify(|existing| existing.extend(&coords))
                     .or_insert(coords);
             }
         }
         map
+    }
+
+    /// Alias for `all_unique_dim_coords` — returns every dimension and its
+    /// merged coordinate values across the whole tree.
+    pub fn axes(&mut self) -> BTreeMap<String, Coordinates> {
+        self.all_unique_dim_coords()
+    }
+
+    /// Return the set of dimension names present in the tree.
+    pub fn dimensions(&mut self) -> Vec<String> {
+        self.all_unique_dim_coords().into_keys().collect()
     }
 
     pub fn remove_node(&mut self, id: NodeIdx) -> Result<(), String> {
@@ -328,10 +349,26 @@ impl Qube {
         for (should_drop, children) in child_info {
             if should_drop {
                 for child_id in children {
-                    // Splice out: move grandchildren up to node_id, then recurse on them
-                    let grandchildren = self.splice_out_node(child_id, node_id)?;
-                    for gc_id in grandchildren {
-                        self.drop_recurse(gc_id, to_drop)?;
+                    // Splice out: move grandchildren up to node_id, then recurse.
+                    // Re-parented nodes may themselves need dropping, so keep
+                    // splicing until we reach nodes not in to_drop.
+                    let mut pending = self.splice_out_node(child_id, node_id)?;
+                    while !pending.is_empty() {
+                        let mut next_pending = Vec::new();
+                        for gc_id in pending {
+                            let gc_should_drop = self
+                                .node_ref(gc_id)
+                                .and_then(|n| self.dimension_str(&n.dim()))
+                                .map(|s| to_drop.contains(s))
+                                .unwrap_or(false);
+                            if gc_should_drop {
+                                next_pending
+                                    .extend(self.splice_out_node(gc_id, node_id)?);
+                            } else {
+                                self.drop_recurse(gc_id, to_drop)?;
+                            }
+                        }
+                        pending = next_pending;
                     }
                 }
             } else {
@@ -361,6 +398,20 @@ impl Qube {
 
     pub fn dimension_str(&self, dim: &Dimension) -> Option<&str> {
         self.key_store.try_resolve(&dim.0)
+    }
+
+    /// Intern a dimension name into this Qube's key_store, returning the Dimension ID.
+    pub(crate) fn get_or_intern_dim(&mut self, name: &str) -> Dimension {
+        Dimension(self.key_store.get_or_intern(name))
+    }
+
+    /// Return all unique Dimension IDs used by nodes in this Qube.
+    pub(crate) fn all_dim_ids(&self) -> Vec<Dimension> {
+        let mut seen = HashSet::new();
+        for (_id, node) in self.nodes.iter() {
+            seen.insert(node.dim);
+        }
+        seen.into_iter().collect()
     }
 
     pub(crate) fn invalidate_ancestors(&self, id: NodeIdx) {

--- a/qubed/src/serde/json.rs
+++ b/qubed/src/serde/json.rs
@@ -341,6 +341,104 @@ fn serialize_children_json(qube: &Qube, parent_id: NodeIdx, output: &mut Map<Str
     }
 }
 
+// ---------------- Tree JSON (key/values/metadata/children) ----------------
+
+impl Qube {
+    /// Serialize the Qube into a recursive tree JSON layout where each node has:
+    /// `{ "key": <dim>, "values": { "type": "enum", "dtype": <type>, "values": [...] }, "metadata": {}, "children": [...] }`
+    pub fn to_tree_json(&self) -> Value {
+        serialize_tree_node(self, self.root())
+    }
+
+    /// Reconstruct a Qube from a tree JSON layout created by `to_tree_json`.
+    pub fn from_tree_json(value: Value) -> Result<Qube, String> {
+        let mut qube = Qube::new();
+        let root = qube.root();
+        parse_tree_node(&mut qube, root, &value)?;
+        Ok(qube)
+    }
+}
+
+fn coords_dtype(coords: &Coordinates) -> &'static str {
+    match coords {
+        Coordinates::Empty => "str",
+        Coordinates::Integers(_) => "int64",
+        Coordinates::Floats(_) => "float64",
+        Coordinates::Strings(_) => "str",
+        Coordinates::DateTimes(_) => "datetime",
+        Coordinates::Mixed(_) => "mixed",
+    }
+}
+
+fn serialize_tree_node(qube: &Qube, node_id: NodeIdx) -> Value {
+    let node = qube.node(node_id).expect("valid node");
+    let key = node.dimension().unwrap_or("root").to_string();
+    let coords = node.coordinates();
+
+    let dtype = coords_dtype(coords);
+    let values_array = coords.to_json_value();
+
+    let mut values_obj = Map::new();
+    values_obj.insert("type".to_string(), Value::String("enum".to_string()));
+    values_obj.insert("dtype".to_string(), Value::String(dtype.to_string()));
+    // Ensure values is always an array
+    let values_arr = match values_array {
+        Value::Array(a) => Value::Array(a),
+        other => Value::Array(vec![other]),
+    };
+    values_obj.insert("values".to_string(), values_arr);
+
+    let children_ids: Vec<NodeIdx> = node.all_children().collect();
+    let children: Vec<Value> = children_ids
+        .iter()
+        .map(|&child_id| serialize_tree_node(qube, child_id))
+        .collect();
+
+    let mut map = Map::new();
+    map.insert("key".to_string(), Value::String(key));
+    map.insert("values".to_string(), Value::Object(values_obj));
+    map.insert("metadata".to_string(), Value::Object(Map::new()));
+    map.insert("children".to_string(), Value::Array(children));
+
+    Value::Object(map)
+}
+
+fn parse_tree_node(qube: &mut Qube, parent: NodeIdx, value: &Value) -> Result<(), String> {
+    let obj = value.as_object().ok_or("Expected JSON object for tree node")?;
+
+    let children = obj
+        .get("children")
+        .and_then(|v| v.as_array())
+        .ok_or("Missing 'children' array")?;
+
+    for child_value in children {
+        let child_obj = child_value
+            .as_object()
+            .ok_or("Expected JSON object for child node")?;
+
+        let key = child_obj
+            .get("key")
+            .and_then(|v| v.as_str())
+            .ok_or("Missing 'key' in child node")?;
+
+        let values_obj = child_obj
+            .get("values")
+            .and_then(|v| v.as_object())
+            .ok_or("Missing 'values' object in child node")?;
+
+        let values_array = values_obj
+            .get("values")
+            .ok_or("Missing 'values' array in values object")?;
+
+        let coords = Coordinates::from_json_value(values_array)?;
+
+        let child_node = qube.get_or_create_child(key, parent, Some(coords))?;
+        parse_tree_node(qube, child_node, child_value)?;
+    }
+
+    Ok(())
+}
+
 // ---------------- Tests ----------------
 
 // TODO: The JSON structure should probably be more detailed, possibly splitting values and children into separate fields, possibly containing type information for the values too.

--- a/qubed/src/serde/json.rs
+++ b/qubed/src/serde/json.rs
@@ -389,10 +389,8 @@ fn serialize_tree_node(qube: &Qube, node_id: NodeIdx) -> Value {
     values_obj.insert("values".to_string(), values_arr);
 
     let children_ids: Vec<NodeIdx> = node.all_children().collect();
-    let children: Vec<Value> = children_ids
-        .iter()
-        .map(|&child_id| serialize_tree_node(qube, child_id))
-        .collect();
+    let children: Vec<Value> =
+        children_ids.iter().map(|&child_id| serialize_tree_node(qube, child_id)).collect();
 
     let mut map = Map::new();
     map.insert("key".to_string(), Value::String(key));
@@ -406,29 +404,22 @@ fn serialize_tree_node(qube: &Qube, node_id: NodeIdx) -> Value {
 fn parse_tree_node(qube: &mut Qube, parent: NodeIdx, value: &Value) -> Result<(), String> {
     let obj = value.as_object().ok_or("Expected JSON object for tree node")?;
 
-    let children = obj
-        .get("children")
-        .and_then(|v| v.as_array())
-        .ok_or("Missing 'children' array")?;
+    let children =
+        obj.get("children").and_then(|v| v.as_array()).ok_or("Missing 'children' array")?;
 
     for child_value in children {
-        let child_obj = child_value
-            .as_object()
-            .ok_or("Expected JSON object for child node")?;
+        let child_obj = child_value.as_object().ok_or("Expected JSON object for child node")?;
 
-        let key = child_obj
-            .get("key")
-            .and_then(|v| v.as_str())
-            .ok_or("Missing 'key' in child node")?;
+        let key =
+            child_obj.get("key").and_then(|v| v.as_str()).ok_or("Missing 'key' in child node")?;
 
         let values_obj = child_obj
             .get("values")
             .and_then(|v| v.as_object())
             .ok_or("Missing 'values' object in child node")?;
 
-        let values_array = values_obj
-            .get("values")
-            .ok_or("Missing 'values' array in values object")?;
+        let values_array =
+            values_obj.get("values").ok_or("Missing 'values' array in values object")?;
 
         let coords = Coordinates::from_json_value(values_array)?;
 


### PR DESCRIPTION
> [!WARNING]
> This is the full set of changes that were needed to restore functionality for Forecast-In-A-Box.
> They were agentically built, and have no care for correctness to the vision of `qubed`.
> Let this serve as a showcase as to what was needed, to begin discussion.

> [!IMPORTANT]
> This PR has been split into focused, independently-mergeable PRs below.
> Each can be reviewed and merged on its own. This PR represents the sum of all changes.

## Split PRs

| PR | Scope | Status |
|----|-------|--------|
| #104 | **fix(coordinates):** consistent leading-zero handling, safe intersection, type coercion | Draft |
| #105 | **fix(merge):** safe cross-Qube dimension merging with translation map | Draft |
| #106 | **feat(serde):** add tree JSON serialisation format | Draft |
| #107 | **feat(datacube):** deterministic dimension ordering in from_datacube | Draft |
| #108 | **feat(py_qubed):** ergonomic Python API with immutable ops and new surface | Draft |

Each PR is independently mergeable. #108 includes all Rust-level dependencies so it can land on its own if preferred as a single merge.

---

## Full summary of changes

### Core Rust library (`qubed/src/`)

**Coordinates** (`coordinates/mod.rs`, `coordinates/ops.rs`) — #104
- Fix coordinate intersection to return `Empty` instead of panicking on cross-type or empty operands
- Implement `Mixed` coordinates `to_string()` formatting (was `todo!()`)
- Fix leading-zero detection: consistent across multi-value coordinate strings
- Add type coercion between `Strings` and `Integers` when extending coordinates

**Merge** (`merge.rs`) — #105
- Build a dimension translation map before merging, so two Qubes with dimensions interned in different orders merge correctly
- Handle the case where a dimension exists only in `other` during `node_merge`

**Qube** (`qube.rs`) — #105
- Add `Clone` for `Node` and `Qube`
- Add `axes()`, `dimensions()`, `all_dim_ids()`, `get_or_intern_dim()`, `prepend()` methods
- Fix `drop_recurse` to iteratively splice out consecutive matching dimensions

**Datacube** (`datacube.rs`) — #107
- `from_datacube` sorts remaining dimensions alphabetically for deterministic tree structure

**Serialisation** (`serde/json.rs`) — #106
- Add `to_tree_json` / `from_tree_json`: recursive format with key, values, metadata, children fields

### Python bindings (`py_qubed/src/lib.rs`) — #108

**Breaking changes:**
- Class renamed from `PyQube` to `Qube` on the Python side
- `drop()` and `squeeze()` return a new Qube instead of mutating in place
- `to_datacubes()` and `all_unique_dim_coords()` return native Python types
- `from_arena_json()` now accepts `str | dict`

**New API surface:**
- `Qube.empty()`, `Qube.is_empty()`
- `Qube.from_json()` / `to_json()`, `from_tree_json()` / `to_tree_json()`
- `axes()`, `dimensions()`
- `__or__` operator, `__copy__` / `__deepcopy__` support
- `from_datacube` preserves Python dict insertion order
- Datacube dicts accept `list`, `int`, `float` values

### Tests & Docs
- All tests updated, new test files added
- `docs/src/python/py_qubed.md` rewritten