### PR TITLE
fix(merge): safe cross-Qube dimension merging with translation map

### DIFF
--- a/qubed/src/coordinates/mod.rs
+++ b/qubed/src/coordinates/mod.rs
@@ -54,14 +54,18 @@ impl Coordinates {
         let mut coords = Coordinates::Empty;
         let split: Vec<&str> = s.split('/').collect();
 
-        for part in split {
-            // Check for leading zeros to preserve formatting (e.g., "0001")
-            let has_leading_zero = part.len() > 1
-                && part.starts_with('0')
-                && part.chars().nth(1).map_or(false, |c| c.is_ascii_digit());
+        // When multiple values are present, ensure consistent typing:
+        // if all parse as integers but some have leading zeros, keep all as strings.
+        let all_int = split.iter().all(|p| p.parse::<i32>().is_ok());
+        let any_leading_zero = split.iter().any(|p| {
+            p.len() > 1
+                && p.starts_with('0')
+                && p.chars().nth(1).map_or(false, |c| c.is_ascii_digit())
+        });
+        let force_strings = all_int && any_leading_zero;
 
-            if has_leading_zero {
-                // Preserve as string to keep formatting
+        for part in split {
+            if force_strings {
                 coords.append(part.to_string());
             } else if let Ok(int_val) = part.parse::<i32>() {
                 coords.append(int_val);
@@ -81,8 +85,25 @@ impl Coordinates {
             Coordinates::Floats(floats) => floats.to_string(),
             Coordinates::DateTimes(datetimes) => datetimes.to_string(),
             Coordinates::Strings(strings) => strings.to_string(),
-            Coordinates::Mixed(_) => {
-                todo!()
+            Coordinates::Mixed(mixed) => {
+                let mut parts: Vec<String> = Vec::new();
+                let ints_str = mixed.integers.to_string();
+                if !ints_str.is_empty() {
+                    parts.push(ints_str);
+                }
+                let floats_str = mixed.floats.to_string();
+                if !floats_str.is_empty() {
+                    parts.push(floats_str);
+                }
+                let strings_str = mixed.strings.to_string();
+                if !strings_str.is_empty() {
+                    parts.push(strings_str);
+                }
+                let datetimes_str = mixed.datetimes.to_string();
+                if !datetimes_str.is_empty() {
+                    parts.push(datetimes_str);
+                }
+                parts.join("/")
             }
         }
     }
@@ -157,27 +178,52 @@ impl Coordinates {
         self
     }
 
+    fn type_name(&self) -> &'static str {
+        match self {
+            Coordinates::Empty => "Empty",
+            Coordinates::Integers(_) => "Integers",
+            Coordinates::Floats(_) => "Floats",
+            Coordinates::Strings(_) => "Strings",
+            Coordinates::DateTimes(_) => "DateTimes",
+            Coordinates::Mixed(_) => "Mixed",
+        }
+    }
+
     pub fn intersect(&self, _other: &Coordinates) -> IntersectionResult<Coordinates> {
         match (self, _other) {
             (Coordinates::Integers(ints_a), Coordinates::Integers(ints_b)) => {
                 let result = ints_a.intersect(ints_b);
                 IntersectionResult {
-                    intersection: Coordinates::Integers(result.intersection),
-                    only_a: Coordinates::Integers(result.only_a),
-                    only_b: Coordinates::Integers(result.only_b),
+                    intersection: wrap_ints(result.intersection),
+                    only_a: wrap_ints(result.only_a),
+                    only_b: wrap_ints(result.only_b),
                 }
             }
             (Coordinates::Strings(strs_a), Coordinates::Strings(strs_b)) => {
                 let result = strs_a.intersect(strs_b);
                 IntersectionResult {
-                    intersection: Coordinates::Strings(result.intersection),
-                    only_a: Coordinates::Strings(result.only_a),
-                    only_b: Coordinates::Strings(result.only_b),
+                    intersection: wrap_strs(result.intersection),
+                    only_a: wrap_strs(result.only_a),
+                    only_b: wrap_strs(result.only_b),
                 }
             }
-            _ => {
-                unimplemented!("Intersection not implemented for these coordinate types");
-            }
+            // Empty on either side: intersection is empty; the non-empty side goes to its slot.
+            (Coordinates::Empty, _) => IntersectionResult {
+                intersection: Coordinates::Empty,
+                only_a: Coordinates::Empty,
+                only_b: _other.clone(),
+            },
+            (_, Coordinates::Empty) => IntersectionResult {
+                intersection: Coordinates::Empty,
+                only_a: self.clone(),
+                only_b: Coordinates::Empty,
+            },
+            // Cross-type: no values can be shared, so intersection is empty.
+            _ => IntersectionResult {
+                intersection: Coordinates::Empty,
+                only_a: self.clone(),
+                only_b: _other.clone(),
+            },
         }
     }
 
@@ -217,6 +263,14 @@ impl Default for Coordinates {
 }
 
 // ------------- Intersection ------------------
+
+fn wrap_ints(c: integers::IntegerCoordinates) -> Coordinates {
+    if c.len() == 0 { Coordinates::Empty } else { Coordinates::Integers(c) }
+}
+
+fn wrap_strs(c: strings::StringCoordinates) -> Coordinates {
+    if c.len() == 0 { Coordinates::Empty } else { Coordinates::Strings(c) }
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct IntersectionResult<T> {
@@ -507,5 +561,124 @@ impl Coordinates {
             Value::String(s) => Ok(Coordinates::from_string(s)),
             _ => Err("Unsupported coords JSON value".to_string()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ints(vals: &[i32]) -> Coordinates {
+        let mut c = Coordinates::Empty;
+        for &v in vals {
+            c.append(v);
+        }
+        c
+    }
+
+    fn strs(vals: &[&str]) -> Coordinates {
+        let mut c = Coordinates::Empty;
+        for &v in vals {
+            c.append(v.to_string());
+        }
+        c
+    }
+
+    // ---- Integers ∩ Integers ------------------------------------------------
+
+    #[test]
+    fn intersect_integers_overlapping() {
+        let result = ints(&[1, 2, 3]).intersect(&ints(&[2, 3, 4]));
+        assert_eq!(result.intersection, ints(&[2, 3]));
+        assert_eq!(result.only_a, ints(&[1]));
+        assert_eq!(result.only_b, ints(&[4]));
+    }
+
+    #[test]
+    fn intersect_integers_disjoint() {
+        let result = ints(&[1, 2]).intersect(&ints(&[3, 4]));
+        assert_eq!(result.intersection, Coordinates::Empty);
+        assert_eq!(result.only_a, ints(&[1, 2]));
+        assert_eq!(result.only_b, ints(&[3, 4]));
+    }
+
+    #[test]
+    fn intersect_integers_identical() {
+        let result = ints(&[5, 10]).intersect(&ints(&[5, 10]));
+        assert_eq!(result.intersection, ints(&[5, 10]));
+        assert_eq!(result.only_a, Coordinates::Empty);
+        assert_eq!(result.only_b, Coordinates::Empty);
+    }
+
+    // ---- Strings ∩ Strings --------------------------------------------------
+
+    #[test]
+    fn intersect_strings_overlapping() {
+        let result = strs(&["a", "b", "c"]).intersect(&strs(&["b", "c", "d"]));
+        assert_eq!(result.intersection, strs(&["b", "c"]));
+        assert_eq!(result.only_a, strs(&["a"]));
+        assert_eq!(result.only_b, strs(&["d"]));
+    }
+
+    #[test]
+    fn intersect_strings_disjoint() {
+        let result = strs(&["pf"]).intersect(&strs(&["fc"]));
+        assert_eq!(result.intersection, Coordinates::Empty);
+        assert_eq!(result.only_a, strs(&["pf"]));
+        assert_eq!(result.only_b, strs(&["fc"]));
+    }
+
+    #[test]
+    fn intersect_strings_identical() {
+        let result = strs(&["od"]).intersect(&strs(&["od"]));
+        assert_eq!(result.intersection, strs(&["od"]));
+        assert_eq!(result.only_a, Coordinates::Empty);
+        assert_eq!(result.only_b, Coordinates::Empty);
+    }
+
+    // ---- Empty cases --------------------------------------------------------
+
+    #[test]
+    fn intersect_empty_with_integers() {
+        let result = Coordinates::Empty.intersect(&ints(&[1, 2, 3]));
+        assert_eq!(result.intersection, Coordinates::Empty);
+        assert_eq!(result.only_a, Coordinates::Empty);
+        assert_eq!(result.only_b, ints(&[1, 2, 3]));
+    }
+
+    #[test]
+    fn intersect_integers_with_empty() {
+        let result = ints(&[1, 2, 3]).intersect(&Coordinates::Empty);
+        assert_eq!(result.intersection, Coordinates::Empty);
+        assert_eq!(result.only_a, ints(&[1, 2, 3]));
+        assert_eq!(result.only_b, Coordinates::Empty);
+    }
+
+    #[test]
+    fn intersect_empty_with_strings() {
+        let result = Coordinates::Empty.intersect(&strs(&["pf"]));
+        assert_eq!(result.intersection, Coordinates::Empty);
+        assert_eq!(result.only_a, Coordinates::Empty);
+        assert_eq!(result.only_b, strs(&["pf"]));
+    }
+
+    #[test]
+    fn intersect_empty_with_empty() {
+        let result = Coordinates::Empty.intersect(&Coordinates::Empty);
+        assert_eq!(result.intersection, Coordinates::Empty);
+        assert_eq!(result.only_a, Coordinates::Empty);
+        assert_eq!(result.only_b, Coordinates::Empty);
+    }
+
+    #[test]
+    fn from_string_splits_on_slash() {
+        let c = Coordinates::from_string("1/2/3");
+        assert_eq!(c, ints(&[1, 2, 3]));
+
+        let c = Coordinates::from_string("od/rd");
+        assert_eq!(c, strs(&["od", "rd"]));
+
+        let c = Coordinates::from_string("single");
+        assert_eq!(c, strs(&["single"]));
     }
 }

--- a/qubed/src/coordinates/ops.rs
+++ b/qubed/src/coordinates/ops.rs
@@ -1,5 +1,8 @@
 use crate::Coordinates;
 use crate::coordinates::CoordinateTypes;
+use crate::coordinates::integers::IntegerCoordinates;
+use crate::coordinates::strings::StringCoordinates;
+use crate::utils::tiny_ordered_set::TinyOrderedSet;
 use chrono::NaiveDateTime;
 
 impl From<NaiveDateTime> for CoordinateTypes {
@@ -24,6 +27,16 @@ impl Coordinates {
             Coordinates::Integers(new_ints) => match self {
                 Coordinates::Integers(ints) => {
                     ints.extend(new_ints);
+                }
+                Coordinates::Strings(strings) => {
+                    // Try to coerce all strings to integers
+                    if let Some(converted) = try_strings_to_integers(strings) {
+                        let mut merged = converted;
+                        merged.extend(new_ints);
+                        *self = Coordinates::Integers(merged);
+                    } else {
+                        self.convert_to_mixed().extend(new_coords);
+                    }
                 }
                 Coordinates::Mixed(mixed) => {
                     mixed.integers.extend(new_ints);
@@ -52,6 +65,14 @@ impl Coordinates {
             Coordinates::Strings(new_strings) => match self {
                 Coordinates::Strings(strings) => {
                     strings.extend(new_strings);
+                }
+                Coordinates::Integers(ints) => {
+                    // Try to coerce all new strings to integers
+                    if let Some(converted) = try_strings_to_integers(new_strings) {
+                        ints.extend(&converted);
+                    } else {
+                        self.convert_to_mixed().extend(new_coords);
+                    }
                 }
                 Coordinates::Mixed(mixed) => {
                     mixed.strings.extend(new_strings);
@@ -239,5 +260,33 @@ impl From<f64> for CoordinateTypes {
 impl From<String> for CoordinateTypes {
     fn from(val: String) -> Self {
         CoordinateTypes::String(val)
+    }
+}
+
+/// Attempt to convert all values in a StringCoordinates to integers.
+/// Returns Some(IntegerCoordinates) if every string parses as i32 and none
+/// have leading zeros (which would lose formatting information), None otherwise.
+fn try_strings_to_integers(strings: &StringCoordinates) -> Option<IntegerCoordinates> {
+    match strings {
+        StringCoordinates::Set(set) => {
+            let mut int_set: TinyOrderedSet<i32, 6> = TinyOrderedSet::new();
+            for s in set.iter() {
+                let s_str = s.to_string();
+                // Reject strings with leading zeros to preserve formatting
+                if s_str.len() > 1
+                    && s_str.starts_with('0')
+                    && s_str.chars().nth(1).map_or(false, |c| c.is_ascii_digit())
+                {
+                    return None;
+                }
+                match s_str.parse::<i32>() {
+                    Ok(val) => {
+                        int_set.insert(val);
+                    }
+                    Err(_) => return None,
+                }
+            }
+            Some(IntegerCoordinates::Set(int_set))
+        }
     }
 }

--- a/qubed/src/merge.rs
+++ b/qubed/src/merge.rs
@@ -1,12 +1,33 @@
 use crate::qube::Dimension;
 use crate::{NodeIdx, Qube};
 use std::collections::HashMap;
-use std::time::Instant;
 
 impl Qube {
+    /// Build a mapping from `other`'s dimension IDs to `self`'s dimension IDs
+    /// by interning all of `other`'s dimension names into `self`'s key_store.
+    /// This allows us to compare dimensions by ID rather than string in the merge loop.
+    fn build_dim_translation(&mut self, other: &Qube) -> HashMap<Dimension, Dimension> {
+        let mut map = HashMap::new();
+        for other_dim in other.all_dim_ids() {
+            if let Some(name) = other.dimension_str(&other_dim) {
+                let self_dim = self.get_or_intern_dim(name);
+                map.insert(other_dim, self_dim);
+            }
+        }
+        map
+    }
+
     /// Performs a union operation between two nodes in two different Qubes.
-    fn node_merge(&mut self, other: &mut Qube, self_id: NodeIdx, other_id: NodeIdx) -> NodeIdx {
-        // Group the children of both nodes into groups according to their associated dimensions.
+    fn node_merge(
+        &mut self,
+        other: &mut Qube,
+        self_id: NodeIdx,
+        other_id: NodeIdx,
+        dim_map: &HashMap<Dimension, Dimension>,
+    ) -> NodeIdx {
+        // Group children by dimension, using self's dimension IDs (via the translation map)
+        // so that same-named dimensions from both qubes are matched correctly regardless of
+        // interner ordering.
         let self_children = {
             let node = self.node_ref(self_id).unwrap();
             node.children().clone()
@@ -17,26 +38,43 @@ impl Qube {
             node.children().clone()
         };
 
-        // Create a map of dimensions to (self_children, other_children).
         let mut dim_child_map: HashMap<Dimension, (Vec<NodeIdx>, Vec<NodeIdx>)> = HashMap::new();
 
         for (dim, self_kids) in self_children {
             dim_child_map.entry(dim).or_default().0.extend(self_kids);
         }
         for (dim, other_kids) in other_children {
-            dim_child_map.entry(dim).or_default().1.extend(other_kids);
+            // Translate other's dimension ID to self's namespace
+            let self_dim = dim_map.get(&dim).copied().unwrap_or(dim);
+            dim_child_map.entry(self_dim).or_default().1.extend(other_kids);
         }
 
         // For each dimension, perform an internal set operation on the groups.
-        let dims: Vec<_> = dim_child_map.keys().copied().collect();
+        let dims: Vec<Dimension> = dim_child_map.keys().copied().collect();
 
         for dim in dims {
             let (these_kids, those_kids) = {
                 let entry = dim_child_map.entry(dim).or_default();
-                (&entry.0, &entry.1)
+                (entry.0.clone(), entry.1.clone())
             };
 
-            let _new_children = self.internal_set_operation(other, these_kids, those_kids);
+            if these_kids.is_empty() {
+                // Dimension exists only in `other`: copy every node (and its subtree) into self.
+                for other_node in those_kids {
+                    let (dim_str, coords) = {
+                        let n = other.node_ref(other_node).unwrap();
+                        let d = other.dimension_str(n.dim()).unwrap().to_owned();
+                        let c = n.coords().clone();
+                        (d, c)
+                    };
+                    let new_child =
+                        self.get_or_create_child(&dim_str, self_id, Some(coords)).unwrap();
+                    self.copy_subtree(other, other_node, new_child);
+                }
+            } else {
+                let _new_children =
+                    self.internal_set_operation(other, &these_kids, &those_kids, dim_map);
+            }
         }
 
         return self.root();
@@ -46,8 +84,9 @@ impl Qube {
     fn internal_set_operation(
         &mut self,
         other: &mut Qube,
-        self_ids: &Vec<NodeIdx>,
-        other_ids: &Vec<NodeIdx>,
+        self_ids: &[NodeIdx],
+        other_ids: &[NodeIdx],
+        dim_map: &HashMap<Dimension, Dimension>,
     ) -> Option<Vec<NodeIdx>> {
         let mut return_vec = Vec::new();
 
@@ -106,7 +145,7 @@ impl Qube {
                         other.copy_branch(*other_node, new_node_b);
                     }
 
-                    let _nested_result = self.node_merge(other, new_node_a, new_node_b);
+                    let _nested_result = self.node_merge(other, new_node_a, new_node_b, dim_map);
                 }
 
                 // If there are values only in self, update the coordinates of the current node.
@@ -152,9 +191,13 @@ impl Qube {
             return;
         }
 
+        // Pre-intern all of other's dimension names into self's key_store so we can
+        // compare dimensions by ID rather than string throughout the recursive merge.
+        let dim_map = self.build_dim_translation(other);
+
         let self_root_id = self.root();
         let other_root_id = other.root();
-        self.node_merge(other, self_root_id, other_root_id);
+        self.node_merge(other, self_root_id, other_root_id, &dim_map);
         self.compress();
         // Clear the other Qube
         *other = Qube::new();
@@ -164,11 +207,14 @@ impl Qube {
     pub fn append_many(&mut self, others: &mut Vec<Qube>) {
         let others_len = others.len();
         for (i, other) in others.iter_mut().enumerate() {
+            // Build translation map for each other qube
+            let dim_map = self.build_dim_translation(other);
+
             let self_root_id = self.root();
             let other_root_id = other.root();
 
             // Perform the union with the current Qube
-            self.node_merge(other, self_root_id, other_root_id);
+            self.node_merge(other, self_root_id, other_root_id, &dim_map);
 
             // Print progress update
             println!("Union completed for Qube {}/{}", i + 1, others_len);
@@ -181,5 +227,56 @@ impl Qube {
         }
         // Final compression after all unions are complete
         self.compress();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Coordinates;
+    use crate::datacube::Datacube;
+
+    fn dc(pairs: &[(&str, &str)]) -> Datacube {
+        let mut d = Datacube::new();
+        for &(k, v) in pairs {
+            d.add_coordinate(k, Coordinates::from_string(v));
+        }
+        d
+    }
+
+    /// Appending two Qubes whose dimensions were interned in a different order
+    /// must not cross-intersect coordinates from different dimension names.
+    /// Before the fix, the shared integer dimension ID caused e.g. `number` coords
+    /// to be intersected against `time` coords, producing a panic.
+    #[test]
+    fn append_qubes_with_different_dimension_interning_order() {
+        // First Qube: dimensions added in order a, b, c
+        let mut q1 = Qube::from_datacube(&dc(&[("a", "1"), ("b", "x"), ("c", "10")]), None);
+
+        // Second Qube: dimensions added in order c, b, a — interner assigns IDs in the opposite
+        // order, so `a` in q2 gets the same integer ID as `c` in q1.
+        let mut q2 = Qube::from_datacube(&dc(&[("c", "20"), ("b", "y"), ("a", "2")]), None);
+
+        // Must not panic.
+        q1.append(&mut q2);
+
+        let ascii = q1.to_ascii();
+        assert!(ascii.contains("a=1") || ascii.contains("a=2"), "a values lost: {ascii}");
+        assert!(ascii.contains("b=x") || ascii.contains("b=y"), "b values lost: {ascii}");
+        assert!(ascii.contains("c=10") || ascii.contains("c=20"), "c values lost: {ascii}");
+    }
+
+    #[test]
+    fn append_qubes_all_shared_dimensions_merged() {
+        let mut q1 = Qube::from_datacube(&dc(&[("class", "od"), ("step", "0/6/12")]), None);
+        let mut q2 = Qube::from_datacube(&dc(&[("class", "od"), ("step", "18/24")]), None);
+
+        q1.append(&mut q2);
+
+        let coords = q1.all_unique_dim_coords();
+        let steps: std::collections::BTreeSet<String> =
+            coords["step"].to_string().split('/').map(|s| s.to_owned()).collect();
+
+        assert_eq!(steps, ["0", "12", "18", "24", "6"].iter().map(|s| s.to_string()).collect());
     }
 }

--- a/qubed/src/qube.rs
+++ b/qubed/src/qube.rs
@@ -31,7 +31,19 @@ pub(crate) struct Node {
     children: BTreeMap<Dimension, TinyVec<NodeIdx, 4>>,
 }
 
-#[derive(Debug)]
+impl Clone for Node {
+    fn clone(&self) -> Self {
+        Node {
+            dim: self.dim,
+            structural_hash: AtomicU64::new(self.structural_hash.load(Ordering::Relaxed)),
+            coords: self.coords.clone(),
+            parent: self.parent,
+            children: self.children.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct Qube {
     nodes: SlotMap<NodeIdx, Node>,
     root_id: NodeIdx,
@@ -195,22 +207,31 @@ impl Qube {
     }
 
     pub fn all_unique_dim_coords(&mut self) -> BTreeMap<String, Coordinates> {
-        // TODO
         let mut map: BTreeMap<String, Coordinates> = BTreeMap::new();
 
         for (_id, node) in self.nodes.iter() {
             if let Some(dim_str) = self.dimension_str(&node.dim) {
                 let coords = node.coords.clone();
                 if coords.is_empty() {
-                    continue; // Skip empty coordinates
+                    continue;
                 }
-                // if there is no entry in map for this dimension, just fill it in with coords, otherwise extend the current entry with coords
                 map.entry(dim_str.to_string())
                     .and_modify(|existing| existing.extend(&coords))
                     .or_insert(coords);
             }
         }
         map
+    }
+
+    /// Alias for `all_unique_dim_coords` — returns every dimension and its
+    /// merged coordinate values across the whole tree.
+    pub fn axes(&mut self) -> BTreeMap<String, Coordinates> {
+        self.all_unique_dim_coords()
+    }
+
+    /// Return the set of dimension names present in the tree.
+    pub fn dimensions(&mut self) -> Vec<String> {
+        self.all_unique_dim_coords().into_keys().collect()
     }
 
     pub fn remove_node(&mut self, id: NodeIdx) -> Result<(), String> {
@@ -328,10 +349,25 @@ impl Qube {
         for (should_drop, children) in child_info {
             if should_drop {
                 for child_id in children {
-                    // Splice out: move grandchildren up to node_id, then recurse on them
-                    let grandchildren = self.splice_out_node(child_id, node_id)?;
-                    for gc_id in grandchildren {
-                        self.drop_recurse(gc_id, to_drop)?;
+                    // Splice out: move grandchildren up to node_id, then recurse.
+                    // Re-parented nodes may themselves need dropping, so keep
+                    // splicing until we reach nodes not in to_drop.
+                    let mut pending = self.splice_out_node(child_id, node_id)?;
+                    while !pending.is_empty() {
+                        let mut next_pending = Vec::new();
+                        for gc_id in pending {
+                            let gc_should_drop = self
+                                .node_ref(gc_id)
+                                .and_then(|n| self.dimension_str(&n.dim()))
+                                .map(|s| to_drop.contains(s))
+                                .unwrap_or(false);
+                            if gc_should_drop {
+                                next_pending.extend(self.splice_out_node(gc_id, node_id)?);
+                            } else {
+                                self.drop_recurse(gc_id, to_drop)?;
+                            }
+                        }
+                        pending = next_pending;
                     }
                 }
             } else {
@@ -355,12 +391,38 @@ impl Qube {
         self.drop(to_drop)
     }
 
+    /// Wrap the entire tree under a new parent node with the given dimension and coordinates.
+    /// Returns a new Qube where root -> new_node -> (original root's children).
+    pub fn prepend(&self, dim: &str, coords: Coordinates) -> Self {
+        let mut new_qube = Qube::new();
+        let new_root = new_qube.root();
+        let wrapper_node = new_qube
+            .get_or_create_child(dim, new_root, Some(coords))
+            .expect("Failed to create prepend node");
+        new_qube.copy_subtree(self, self.root(), wrapper_node);
+        new_qube
+    }
+
     pub fn dimension(&self, dim_str: &str) -> Option<Dimension> {
         self.key_store.get(dim_str).map(Dimension)
     }
 
     pub fn dimension_str(&self, dim: &Dimension) -> Option<&str> {
         self.key_store.try_resolve(&dim.0)
+    }
+
+    /// Intern a dimension name into this Qube's key_store, returning the Dimension ID.
+    pub(crate) fn get_or_intern_dim(&mut self, name: &str) -> Dimension {
+        Dimension(self.key_store.get_or_intern(name))
+    }
+
+    /// Return all unique Dimension IDs used by nodes in this Qube.
+    pub(crate) fn all_dim_ids(&self) -> Vec<Dimension> {
+        let mut seen = HashSet::new();
+        for (_id, node) in self.nodes.iter() {
+            seen.insert(node.dim);
+        }
+        seen.into_iter().collect()
     }
 
     pub(crate) fn invalidate_ancestors(&self, id: NodeIdx) {


### PR DESCRIPTION
## Summary

Fixes a critical bug where merging two Qubes built from different sources (with dimensions interned in different orders) would cross-intersect unrelated dimensions, causing panics or silent data corruption.

## Problem

When two Qubes intern their dimensions in different orders, the same integer ID can refer to different dimension names. The merge logic previously compared dimensions by ID directly, meaning e.g. `number` coords could be intersected against `time` coords.

## Solution

### Dimension translation map
- Before merging, build a mapping from `other`'s dimension IDs to `self`'s by interning all of `other`'s dimension names into `self`'s key_store.
- All merge comparisons now go through this map.

### Missing dimension handling
- When a dimension exists only in `other`, copy its entire subtree into `self` (previously silently dropped).

### drop_recurse fix
- Iteratively splice out consecutive matching dimensions instead of only one level (previously could skip intermediate levels).

### Supporting changes
- Add `Clone` for `Node` and `Qube`
- Add `axes()`, `dimensions()`, `all_dim_ids()`, `get_or_intern_dim()`, `prepend()` methods
- Include coordinate intersection safety fixes (return Empty instead of panicking on cross-type/empty operands)

### Tests
- Test merging Qubes with different dimension interning order
- Test that shared dimensions merge correctly

---
Part of the split from #102. Independently mergeable.